### PR TITLE
Hash passwords with bcrypt

### DIFF
--- a/api.go
+++ b/api.go
@@ -98,8 +98,13 @@ func passwordHandler(w http.ResponseWriter, r *http.Request) {
 	username := r.Context().Value("username").(string)
 	updated := slices.Clone(users)
 	for i := range updated {
-		if user := &updated[i]; user.Username == username && user.Password == passwords.Current {
-			user.Password = passwords.New
+		if user := &updated[i]; user.Username == username && bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(passwords.Current)) == nil {
+			password, err := bcrypt.GenerateFromPassword([]byte(passwords.New), bcrypt.DefaultCost)
+			if err != nil {
+				http.Error(w, "Invalid password", http.StatusBadRequest)
+				return
+			}
+			user.Password = string(password)
 			if err := saveUsers(updated); err != nil {
 				logger.Log.Printf("Failed to save user configuration: %v", err)
 				http.Error(w, "Failed to save password", http.StatusInternalServerError)

--- a/api.go
+++ b/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Darep/Beatstream/logger"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"golang.org/x/crypto/bcrypt"
 )
 
 const SongsFilePath = "songs.json"
@@ -145,7 +146,7 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, user := range users {
-		if user.Username == username && user.Password == password {
+		if user.Username == username && bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)) == nil {
 			token := createSession(user).Token
 
 			// Create & set a new cookie

--- a/auth.go
+++ b/auth.go
@@ -56,13 +56,7 @@ func loadUsers() error {
 		migrated = true
 	}
 	if migrated {
-		data, err := json.Marshal(users)
-		if err != nil {
-			return err
-		}
-		if err := os.WriteFile("./users.json", data, 0600); err != nil {
-			return err
-		}
+		return saveUsers(users)
 	}
 
 	return nil
@@ -112,7 +106,29 @@ func saveUsers(updated []User) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile("./users.json", append(data, '\n'), 0o644)
+
+	file, err := os.CreateTemp(".", ".users.json-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(file.Name())
+
+	if err := file.Chmod(0o600); err != nil {
+		file.Close()
+		return err
+	}
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	return os.Rename(file.Name(), "./users.json")
 }
 
 func getSession(token string) *Session {
@@ -161,25 +177,18 @@ func AuthMiddleware(next http.Handler) http.Handler {
 }
 
 func createDefaultUser() (*os.File, error) {
-	// users.json file does not exist, let's add the default user
-	file, err := os.Create("./users.json")
-	if err != nil {
-		return nil, err
-	}
-
 	password, err := bcrypt.GenerateFromPassword([]byte("admin"), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, err
 	}
 
-	err = json.NewEncoder(file).Encode([]User{{Username: "admin", Password: string(password)}})
-	if err != nil {
+	if err := saveUsers([]User{{Username: "admin", Password: string(password)}}); err != nil {
 		return nil, err
 	}
 
 	logger.Log.Println("Created default user \"admin\" in users.json")
 
-	file, err = os.Open("./users.json")
+	file, err := os.Open("./users.json")
 	if err != nil {
 		return nil, err
 	}

--- a/auth.go
+++ b/auth.go
@@ -42,6 +42,29 @@ func loadUsers() error {
 		return err
 	}
 
+	migrated := false
+	for i := range users {
+		if _, err := bcrypt.Cost([]byte(users[i].Password)); err == nil {
+			continue
+		}
+
+		password, err := bcrypt.GenerateFromPassword([]byte(users[i].Password), bcrypt.DefaultCost)
+		if err != nil {
+			return err
+		}
+		users[i].Password = string(password)
+		migrated = true
+	}
+	if migrated {
+		data, err := json.Marshal(users)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile("./users.json", data, 0600); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/auth.go
+++ b/auth.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Darep/Beatstream/logger"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type User struct {
@@ -143,7 +144,12 @@ func createDefaultUser() (*os.File, error) {
 		return nil, err
 	}
 
-	err = json.NewEncoder(file).Encode([]User{{Username: "admin", Password: "admin"}})
+	password, err := bcrypt.GenerateFromPassword([]byte("admin"), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.NewEncoder(file).Encode([]User{{Username: "admin", Password: string(password)}})
 	if err != nil {
 		return nil, err
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -40,5 +44,37 @@ func TestLoadUsersMigratesPlaintextPasswords(t *testing.T) {
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(migrated[0].Password), []byte("secret")); err != nil {
 		t.Fatal("migrated password no longer authenticates")
+	}
+}
+
+func TestPasswordHandlerHashesNewPassword(t *testing.T) {
+	dir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+
+	password, err := bcrypt.GenerateFromPassword([]byte("old"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	users = []User{{Username: "alice", Password: string(password)}}
+	sessions = []Session{{Token: "token", Username: "alice"}}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/password", bytes.NewBufferString(`{"currentPassword":"old","newPassword":"new"}`))
+	req.AddCookie(&http.Cookie{Name: "session", Value: "token"})
+	req = req.WithContext(context.WithValue(req.Context(), "username", "alice"))
+	response := httptest.NewRecorder()
+	passwordHandler(response, req)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", response.Code)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(users[0].Password), []byte("new")); err != nil {
+		t.Fatal("new password was not hashed")
 	}
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestLoadUsersMigratesPlaintextPasswords(t *testing.T) {
+	dir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+
+	if err := os.WriteFile("users.json", []byte(`[{"username":"alice","password":"secret"}]`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := loadUsers(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile("users.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var migrated []User
+	if err := json.Unmarshal(data, &migrated); err != nil {
+		t.Fatal(err)
+	}
+	if migrated[0].Password == "secret" {
+		t.Fatal("password was not migrated")
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(migrated[0].Password), []byte("secret")); err != nil {
+		t.Fatal("migrated password no longer authenticates")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/wtolson/go-taglib v0.0.0-20210406152913-79209c280058
 )
+
+require golang.org/x/crypto v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/wtolson/go-taglib v0.0.0-20210406152913-79209c280058 h1:/kj9W8wSHTlwt/i4n6902i/YOPYNIXiDR/PAmgbrDyc=
 github.com/wtolson/go-taglib v0.0.0-20210406152913-79209c280058/go.mod h1:p+WHGfN/a+Ol37Pm7EIOO/6Cylieb2qn1jmKfxtSsUg=
+golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
+golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=


### PR DESCRIPTION
## What changed

- Hash the default admin password with bcrypt before writing `users.json`.
- Verify login and password-change credentials with bcrypt.
- Store password changes as bcrypt hashes.
- Migrate legacy plaintext passwords to bcrypt when loading existing user files.
- Write all credential updates atomically through a synced temporary file and rename.
- Add `golang.org/x/crypto` as a dependency.
- Cover legacy migration and password changes with regression tests.

## Why

Passwords were previously stored and compared as plaintext. Existing installations need a migration path so upgrading does not lock out their users, and credential writes must not risk truncating the only user file.

## Impact

This PR is stacked on #79 (`codex/password-change`). New installations retain the default `admin` / `admin` login, but passwords stored on disk are bcrypt hashes. Existing plaintext passwords continue to work and are replaced with bcrypt hashes when loaded.

## Validation

- `mise exec go@1.23.5 -- go test ./...`
- `mise exec go@1.23.5 -- go test -race ./...`
- `docker build -f Dockerfile.hub -t beatstream-bcrypt-rebased-test .`
- `git diff --check`