### PR TITLE
Implement password changes

### DIFF
--- a/api.go
+++ b/api.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -88,16 +89,16 @@ func passwordHandler(w http.ResponseWriter, r *http.Request) {
 		Current string `json:"currentPassword"`
 		New     string `json:"newPassword"`
 	}
-	if json.NewDecoder(r.Body).Decode(&passwords) != nil || passwords.New == "" {
+	if err := json.NewDecoder(r.Body).Decode(&passwords); err != nil || passwords.New == "" {
 		http.Error(w, "Invalid password", http.StatusBadRequest)
 		return
 	}
 
 	username := r.Context().Value("username").(string)
-	updated := append([]User(nil), users...)
-	for i, user := range updated {
-		if user.Username == username && user.Password == passwords.Current {
-			updated[i].Password = passwords.New
+	updated := slices.Clone(users)
+	for i := range updated {
+		if user := &updated[i]; user.Username == username && user.Password == passwords.Current {
+			user.Password = passwords.New
 			if err := saveUsers(updated); err != nil {
 				logger.Log.Printf("Failed to save user configuration: %v", err)
 				http.Error(w, "Failed to save password", http.StatusInternalServerError)

--- a/api.go
+++ b/api.go
@@ -61,6 +61,7 @@ func registerRoutes() *chi.Mux {
 
 		r.Get("/session", sessionHandler)
 		r.Delete("/session", logoutHandler)
+		r.Put("/password", passwordHandler)
 
 		r.Get("/songs", songsHandler)
 		r.Get("/songs/play", playHandler)
@@ -79,6 +80,39 @@ func registerRoutes() *chi.Mux {
 	r.Handle("/*", http.HandlerFunc(frontendHandler))
 
 	return r
+}
+
+// PUT /api/password
+func passwordHandler(w http.ResponseWriter, r *http.Request) {
+	var passwords struct {
+		Current string `json:"currentPassword"`
+		New     string `json:"newPassword"`
+	}
+	if json.NewDecoder(r.Body).Decode(&passwords) != nil || passwords.New == "" {
+		http.Error(w, "Invalid password", http.StatusBadRequest)
+		return
+	}
+
+	username := r.Context().Value("username").(string)
+	updated := append([]User(nil), users...)
+	for i, user := range updated {
+		if user.Username == username && user.Password == passwords.Current {
+			updated[i].Password = passwords.New
+			if err := saveUsers(updated); err != nil {
+				logger.Log.Printf("Failed to save user configuration: %v", err)
+				http.Error(w, "Failed to save password", http.StatusInternalServerError)
+				return
+			}
+
+			users = updated
+			cookie, _ := r.Cookie("session")
+			deleteOtherSessions(username, cookie.Value)
+			respondJSON(w, map[string]string{})
+			return
+		}
+	}
+
+	http.Error(w, "Current password is incorrect", http.StatusUnauthorized)
 }
 
 // GET /api/session

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,17 @@
+package main
+
+import "testing"
+
+func TestDeleteOtherSessions(t *testing.T) {
+	sessions = []Session{
+		{Token: "current", Username: "admin"},
+		{Token: "other", Username: "admin"},
+		{Token: "someone-else", Username: "listener"},
+	}
+
+	deleteOtherSessions("admin", "current")
+
+	if len(sessions) != 2 || sessions[0].Token != "current" || sessions[1].Token != "someone-else" {
+		t.Fatalf("unexpected remaining sessions: %#v", sessions)
+	}
+}

--- a/auth.go
+++ b/auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/Darep/Beatstream/logger"
@@ -77,13 +78,9 @@ func deleteSession(token string) {
 }
 
 func deleteOtherSessions(username, currentToken string) {
-	var remaining []Session
-	for _, session := range sessions {
-		if session.Username != username || session.Token == currentToken {
-			remaining = append(remaining, session)
-		}
-	}
-	sessions = remaining
+	sessions = slices.DeleteFunc(sessions, func(session Session) bool {
+		return session.Username == username && session.Token != currentToken
+	})
 }
 
 func saveUsers(updated []User) error {
@@ -91,7 +88,7 @@ func saveUsers(updated []User) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile("./users.json", append(data, '\n'), 0644)
+	return os.WriteFile("./users.json", append(data, '\n'), 0o644)
 }
 
 func getSession(token string) *Session {

--- a/auth.go
+++ b/auth.go
@@ -76,6 +76,24 @@ func deleteSession(token string) {
 	sessions = newSessions
 }
 
+func deleteOtherSessions(username, currentToken string) {
+	var remaining []Session
+	for _, session := range sessions {
+		if session.Username != username || session.Token == currentToken {
+			remaining = append(remaining, session)
+		}
+	}
+	sessions = remaining
+}
+
+func saveUsers(updated []User) error {
+	data, err := json.Marshal(updated)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile("./users.json", append(data, '\n'), 0644)
+}
+
 func getSession(token string) *Session {
 	for _, session := range sessions {
 		if session.Token == token {

--- a/frontend/src/components/PasswordChangeModal.tsx
+++ b/frontend/src/components/PasswordChangeModal.tsx
@@ -1,27 +1,61 @@
+import { type FormEvent, useState } from 'react';
+
+import { ApiError, request } from 'utils/api';
+
 import { Modal } from './common/Modal';
 
-export const PasswordChangeModal = () => {
+export const PasswordChangeModal = ({ onClose }: { onClose: () => void }) => {
+  const [error, setError] = useState<string>();
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    const currentPassword = String(data.get('currentPassword'));
+    const newPassword = String(data.get('newPassword'));
+
+    if (newPassword !== data.get('confirmPassword')) {
+      setError('New passwords do not match');
+      return;
+    }
+
+    setSaving(true);
+    setError(undefined);
+    try {
+      await request('/api/password', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentPassword, newPassword }),
+      });
+      onClose();
+    } catch (error) {
+      setError(error instanceof ApiError && error.status === 401 ? 'Current password is incorrect' : 'Could not change password');
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
-    <Modal onClose={() => null}>
-      <h2>Change password</h2>
-      <label>Current password</label>
-      <div className="form-field">
-        <input type="password" id="current-password" />
-      </div>
-      <label>New password</label>
-      <div className="form-field">
-        <input type="password" id="new-password" />
-      </div>
-      <label>Confirm new password</label>
-      <div className="form-field">
-        <input type="password" id="new-password-2" />
-      </div>
-      <div className="form-field">
-        <input type="submit" className="btn" value="Update Password" />
-        <span className="loading ir" style={{ display: 'none' }}>
-          Saving&hellip;
-        </span>
-      </div>
+    <Modal onClose={onClose}>
+      <form onSubmit={handleSubmit}>
+        <h2>Change password</h2>
+        <label htmlFor="current-password">Current password</label>
+        <div className="form-field">
+          <input required type="password" id="current-password" name="currentPassword" />
+        </div>
+        <label htmlFor="new-password">New password</label>
+        <div className="form-field">
+          <input required type="password" id="new-password" name="newPassword" />
+        </div>
+        <label htmlFor="new-password-2">Confirm new password</label>
+        <div className="form-field">
+          <input required type="password" id="new-password-2" name="confirmPassword" />
+        </div>
+        {error ? <p>{error}</p> : null}
+        <div className="form-field">
+          <input disabled={saving} type="submit" className="btn" value={saving ? 'Saving…' : 'Update Password'} />
+        </div>
+      </form>
     </Modal>
   );
 };

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,9 +1,18 @@
+import { useState } from 'react';
+
 import { useSession } from 'hooks/swr';
 
+import { PasswordChangeModal } from './PasswordChangeModal';
+import { Button } from './common/Button';
 import { Modal } from './common/Modal';
 
 export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
   const { user } = useSession();
+  const [changingPassword, setChangingPassword] = useState(false);
+
+  if (changingPassword) {
+    return <PasswordChangeModal onClose={onClose} />;
+  }
 
   return (
     <Modal onClose={onClose}>
@@ -23,9 +32,9 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
         <label>Password</label>
         <div className="form-field">
           <p>
-            <a id="change-password-link" tabIndex={3}>
+            <Button id="change-password-link" tabIndex={3} variant="plain" onClick={() => setChangingPassword(true)}>
               Change password&hellip;
-            </a>
+            </Button>
           </p>
         </div>
       </section>


### PR DESCRIPTION
## What changed

- finish the password-change modal with current, new, and confirmation fields
- validate matching new passwords and report API errors
- add an authenticated password update endpoint that persists `users.json`
- invalidate the user's other sessions while retaining the current session
- cover session invalidation with a focused Go test

## Why

The settings UI contained a non-functional password-change placeholder. Users could not update credentials, and changing a password needs to revoke other active sessions so old authenticated clients no longer retain access.

## Impact

Users can now change their password from Settings without being logged out of their current browser. Other sessions for that account are logged out.

## Validation

- `docker build --target build -f Dockerfile.hub -t beatstream-password-test .`
- `docker run --rm beatstream-password-test go test ./...`
