### PR TITLE
Fix per-user Last.fm integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@ MUSIC_PATH=~/Music
 # Directory for users.json and songs.json (defaults to the working directory):
 # DATA_PATH=./data
 
+# Last.fm API application credentials:
+# LASTFM_API_KEY=
+# LASTFM_API_SECRET=
+
 # For development:
 ENV=dev
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ vet:
 
 test:
 	go test ./...
+	cd frontend && npm test
 
 check: vet test
 	test -z "$$(gofmt -l $$(git ls-files '*.go'))"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ For reproducible deployments, replace `latest` with an exact release version fro
 
 Open http://0.0.0.0:8080 on your browser. Log in and wait when indexing ends, refresh page and happy listening!
 
+To enable per-user Last.fm connections, create a Last.fm API application and pass its credentials to Beatstream:
+
+```bash
+docker run -d -p 8080:8080 -v /path/to/your/music:/music \
+  -e LASTFM_API_KEY=your-key -e LASTFM_API_SECRET=your-secret \
+  darep/beatstream:latest
+```
+
+Each Beatstream user can then connect and disconnect their own Last.fm account from Settings.
+
 ### Manual Install
 
 Requirements: Go 1.26 or newer. Node.js 20 or newer. TagLib (C bindings) e.g. libtagc

--- a/api.go
+++ b/api.go
@@ -97,9 +97,6 @@ func passwordHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid password", http.StatusBadRequest)
 		return
 	}
-	usersMutex.Lock()
-	defer usersMutex.Unlock()
-
 	username := r.Context().Value("username").(string)
 	updated := slices.Clone(users)
 	for i := range updated {

--- a/api.go
+++ b/api.go
@@ -69,9 +69,12 @@ func registerRoutes() *chi.Mux {
 		r.Get("/songs/refresh", refreshStatusHandler)
 		r.Post("/songs/refresh", refreshHandler)
 
-		// r.Put("/lastfm", lastfmHandler)
-		// r.Post("/lastfm/scrobble", scrobbleHandler)
-		// r.Post("/lastfm/now-playing", nowPlayingHandler)
+		r.Get("/lastfm", lastFMStatusHandler)
+		r.Post("/lastfm/connect", lastFMConnectHandler)
+		r.Post("/lastfm/complete", lastFMCompleteHandler)
+		r.Delete("/lastfm", lastFMDisconnectHandler)
+		r.Post("/lastfm/scrobble", lastFMScrobbleHandler)
+		r.Post("/lastfm/now-playing", lastFMNowPlayingHandler)
 
 		// r.Get("/playlists", playlistsHandler)
 		// r.Post("/playlists", createPlaylistHandler)
@@ -94,6 +97,8 @@ func passwordHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid password", http.StatusBadRequest)
 		return
 	}
+	usersMutex.Lock()
+	defer usersMutex.Unlock()
 
 	username := r.Context().Value("username").(string)
 	updated := slices.Clone(users)

--- a/auth.go
+++ b/auth.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"slices"
-	"sync"
 	"time"
 
 	"github.com/Darep/Beatstream/logger"
@@ -25,15 +24,8 @@ type User struct {
 
 // holds all users in memory
 var users []User
-var usersMutex sync.Mutex
 
 func loadUsers() error {
-	usersMutex.Lock()
-	defer usersMutex.Unlock()
-	return loadUsersUnlocked()
-}
-
-func loadUsersUnlocked() error {
 	file, err := os.Open(usersFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -71,10 +63,6 @@ func loadUsersUnlocked() error {
 	}
 
 	return nil
-}
-
-func saveUsersUnlocked() error {
-	return saveUsers(users)
 }
 
 func currentUser(r *http.Request) *User {

--- a/auth.go
+++ b/auth.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/Darep/Beatstream/logger"
@@ -15,14 +16,24 @@ import (
 )
 
 type User struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username       string `json:"username"`
+	Password       string `json:"password"`
+	LastFMUsername string `json:"lastfm_username,omitempty"`
+	LastFMSession  string `json:"lastfm_session,omitempty"`
+	LastFMToken    string `json:"lastfm_token,omitempty"`
 }
 
 // holds all users in memory
 var users []User
+var usersMutex sync.Mutex
 
 func loadUsers() error {
+	usersMutex.Lock()
+	defer usersMutex.Unlock()
+	return loadUsersUnlocked()
+}
+
+func loadUsersUnlocked() error {
 	file, err := os.Open(usersFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -59,6 +70,20 @@ func loadUsers() error {
 		return saveUsers(users)
 	}
 
+	return nil
+}
+
+func saveUsersUnlocked() error {
+	return saveUsers(users)
+}
+
+func currentUser(r *http.Request) *User {
+	username, _ := r.Context().Value("username").(string)
+	for i := range users {
+		if users[i].Username == username {
+			return &users[i]
+		}
+	}
 	return nil
 }
 

--- a/auth.go
+++ b/auth.go
@@ -15,8 +15,9 @@ import (
 )
 
 type User struct {
-	Username       string `json:"username"`
-	Password       string `json:"password"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+
 	LastFMUsername string `json:"lastfm_username,omitempty"`
 	LastFMSession  string `json:"lastfm_session,omitempty"`
 	LastFMToken    string `json:"lastfm_token,omitempty"`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "preview": "vite preview",
-    "test:e2e": "playwright test",
+    "test": "playwright test unit",
+    "test:e2e": "playwright test e2e",
     "test:e2e:install": "playwright install --with-deps chromium",
     "typecheck": "tsc --noEmit"
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './e2e',
+  testDir: '.',
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
   retries: 0,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { AppLoader } from 'components/AppLoader';
 import { AppMain } from 'components/AppMain';
 import { AppNav } from 'components/AppNav/AppNav';
 import { AppTop } from 'components/AppTop';
+import { LastFMScrobbler } from 'components/LastFMScrobbler';
 import { LoginModal } from 'components/LoginModal';
 import { MediaSession } from 'components/MediaSession';
 import { useSession } from 'hooks/swr';
@@ -36,6 +37,7 @@ export const App = () => {
       <AppLoader />
 
       <MediaSession />
+      {isAuthenticated ? <LastFMScrobbler /> : null}
     </div>
   );
 };

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -4,6 +4,8 @@ import { mutate } from 'swr';
 import { usePlayerStore } from 'store';
 import { ApiError, request } from 'utils/api';
 
+const PLAYBACK_CLOCK_TOLERANCE = 1;
+
 export const LastFMScrobbler = () => {
   const { data: lastFM } = useLastFM();
 
@@ -15,23 +17,28 @@ export const LastFMScrobbler = () => {
     let startedAt = 0;
     let playedSeconds = 0;
     let lastUpdate = Date.now();
+    let lastPosition = 0;
     let previousState: ReturnType<typeof usePlayerStore.getState>['state'] = 'stopped';
     let scrobbled = false;
 
     const sync = (player: ReturnType<typeof usePlayerStore.getState>) => {
-      const { song, state, parsedDuration, playbackInstance } = player;
+      const { song, state, position, parsedDuration, playbackInstance } = player;
       if (!song?.artist || !song.title) return;
 
       const now = Date.now();
       if (playbackInstance === ignoredInstance) {
         lastUpdate = now;
+        lastPosition = position;
         previousState = state;
         return;
       }
       if (currentInstance === playbackInstance && previousState === 'playing') {
-        playedSeconds += (now - lastUpdate) / 1000;
+        const progress = position - lastPosition;
+        const elapsed = (now - lastUpdate) / 1000;
+        if (progress > 0 && progress <= elapsed + PLAYBACK_CLOCK_TOLERANCE) playedSeconds += progress;
       }
       lastUpdate = now;
+      lastPosition = position;
       previousState = state;
 
       const duration = parsedDuration || song.length || 0;

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -9,17 +9,17 @@ export const LastFMScrobbler = () => {
   useEffect(() => {
     if (!lastFM?.connected) return;
 
-    let currentTrack = '';
+    let currentInstance = -1;
     let startedAt = 0;
     let scrobbled = false;
 
     const sync = (player: ReturnType<typeof usePlayerStore.getState>) => {
-      const { song, state, position, parsedDuration } = player;
+      const { song, state, position, parsedDuration, playbackInstance } = player;
       if (!song?.artist || !song.title) return;
 
       const duration = parsedDuration || song.length || 0;
-      if (state === 'playing' && currentTrack !== song.path) {
-        currentTrack = song.path;
+      if (state === 'playing' && currentInstance !== playbackInstance) {
+        currentInstance = playbackInstance;
         startedAt = Math.floor(Date.now() / 1000);
         scrobbled = false;
         void request('/api/lastfm/now-playing', {
@@ -29,7 +29,8 @@ export const LastFMScrobbler = () => {
         }).catch(() => undefined);
       }
 
-      if (currentTrack !== song.path || scrobbled || duration < 30 || position < Math.min(240, duration / 2)) return;
+      if (currentInstance !== playbackInstance || scrobbled || duration < 30 || position < Math.min(240, duration / 2))
+        return;
       scrobbled = true;
       void request('/api/lastfm/scrobble', {
         method: 'POST',

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -1,0 +1,49 @@
+import { useLastFM } from 'hooks/swr';
+import { useEffect, useRef } from 'react';
+import { usePlayerStore } from 'store';
+import { request } from 'utils/api';
+
+export const LastFMScrobbler = () => {
+  const { data: lastFM } = useLastFM();
+  const song = usePlayerStore((state) => state.song);
+  const state = usePlayerStore((state) => state.state);
+  const position = usePlayerStore((state) => state.position);
+  const duration = usePlayerStore((state) => state.parsedDuration || state.song?.length || 0);
+  const startedAt = useRef(0);
+  const announced = useRef('');
+  const scrobbled = useRef('');
+
+  const id = song?.path ?? '';
+
+  useEffect(() => {
+    if (!lastFM?.connected || !song || state !== 'playing' || announced.current === id) return;
+    announced.current = id;
+    scrobbled.current = '';
+    startedAt.current = Math.floor(Date.now() / 1000);
+    void request('/api/lastfm/now-playing', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ artist: song.artist, track: song.title, album: song.album, duration }),
+    }).catch(() => undefined);
+  }, [duration, id, lastFM?.connected, song, state]);
+
+  useEffect(() => {
+    if (!lastFM?.connected || !song || !song.artist || !song.title || duration < 30 || scrobbled.current === id) return;
+    const threshold = Math.min(240, duration / 2);
+    if (!threshold || position < threshold) return;
+    scrobbled.current = id;
+    void request('/api/lastfm/scrobble', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        artist: song.artist,
+        track: song.title,
+        album: song.album,
+        duration,
+        timestamp: startedAt.current,
+      }),
+    }).catch(() => undefined);
+  }, [duration, id, lastFM?.connected, position, song]);
+
+  return null;
+};

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -7,7 +7,7 @@ import { createLastFMPlaybackTracker } from 'utils/LastFMPlayback';
 
 export const LastFMScrobbler = () => {
   const { data: lastFM } = useLastFM();
-  const scrobbledInstances = useRef(new Map<string, number>());
+  const scrobbledPlaybackCounts = useRef(new Map<string, number>());
 
   useEffect(() => {
     if (!lastFM?.connected) return;
@@ -16,14 +16,15 @@ export const LastFMScrobbler = () => {
     let startedAt = 0;
 
     const sync = (player: ReturnType<typeof usePlayerStore.getState>) => {
-      const { song, state, position, parsedDuration, playbackInstance } = player;
+      const { song, state, position, parsedDuration, playbackCount } = player;
+
       if (!song?.artist || !song.title) return;
 
       const duration = parsedDuration || song.length || 0;
 
       const playback = trackPlayback({
         duration,
-        instance: playbackInstance,
+        playbackCount,
         now: performance.now(),
         position,
         state,
@@ -41,11 +42,11 @@ export const LastFMScrobbler = () => {
         });
       }
 
-      if (!playback.shouldScrobble || scrobbledInstances.current.get(lastFM.username) === playbackInstance) {
+      if (!playback.shouldScrobble || scrobbledPlaybackCounts.current.get(lastFM.username) === playbackCount) {
         return;
       }
 
-      scrobbledInstances.current.set(lastFM.username, playbackInstance);
+      scrobbledPlaybackCounts.current.set(lastFM.username, playbackCount);
 
       void request('/api/lastfm/scrobble', {
         method: 'POST',
@@ -65,8 +66,8 @@ export const LastFMScrobbler = () => {
 
     // Set initial state
     sync(usePlayerStore.getState());
-    
-    // Continously sync playback state when state in store updates
+
+    // Continuously sync playback state when state in store updates
     return usePlayerStore.subscribe(sync);
   }, [lastFM?.connected, lastFM?.username]);
 

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -1,7 +1,8 @@
 import { useLastFM } from 'hooks/swr';
 import { useEffect } from 'react';
+import { mutate } from 'swr';
 import { usePlayerStore } from 'store';
-import { request } from 'utils/api';
+import { ApiError, request } from 'utils/api';
 
 export const LastFMScrobbler = () => {
   const { data: lastFM } = useLastFM();
@@ -43,7 +44,10 @@ export const LastFMScrobbler = () => {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ artist: song.artist, track: song.title, album: song.album, duration }),
-        }).catch(() => undefined);
+        }).catch((error: unknown) => {
+          console.error(`Could not update Last.fm now playing for ${song.artist} — ${song.title}`, error);
+          if (error instanceof ApiError && error.status === 409) void mutate('/api/lastfm');
+        });
       }
 
       if (
@@ -64,7 +68,10 @@ export const LastFMScrobbler = () => {
           duration,
           timestamp: startedAt,
         }),
-      }).catch(() => undefined);
+      }).catch((error: unknown) => {
+        console.error(`Could not scrobble ${song.artist} — ${song.title}`, error);
+        if (error instanceof ApiError && error.status === 409) void mutate('/api/lastfm');
+      });
     };
 
     sync(usePlayerStore.getState());

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -1,52 +1,34 @@
 import { useLastFM } from 'hooks/swr';
-import { useEffect } from 'react';
-import { mutate } from 'swr';
+import { useEffect, useRef } from 'react';
 import { usePlayerStore } from 'store';
+import { mutate } from 'swr';
 import { ApiError, request } from 'utils/api';
-
-const PLAYBACK_CLOCK_TOLERANCE = 1;
+import { createLastFMPlaybackTracker } from 'utils/LastFMPlayback';
 
 export const LastFMScrobbler = () => {
   const { data: lastFM } = useLastFM();
+  const scrobbledInstances = useRef(new Map<string, number>());
 
   useEffect(() => {
     if (!lastFM?.connected) return;
 
-    const ignoredInstance = usePlayerStore.getState().playbackInstance;
-    let currentInstance = ignoredInstance;
+    const trackPlayback = createLastFMPlaybackTracker();
     let startedAt = 0;
-    let playedSeconds = 0;
-    let lastUpdate = Date.now();
-    let lastPosition = 0;
-    let previousState: ReturnType<typeof usePlayerStore.getState>['state'] = 'stopped';
-    let scrobbled = false;
 
     const sync = (player: ReturnType<typeof usePlayerStore.getState>) => {
       const { song, state, position, parsedDuration, playbackInstance } = player;
       if (!song?.artist || !song.title) return;
 
-      const now = Date.now();
-      if (playbackInstance === ignoredInstance) {
-        lastUpdate = now;
-        lastPosition = position;
-        previousState = state;
-        return;
-      }
-      if (currentInstance === playbackInstance && previousState === 'playing') {
-        const progress = position - lastPosition;
-        const elapsed = (now - lastUpdate) / 1000;
-        if (progress > 0 && progress <= elapsed + PLAYBACK_CLOCK_TOLERANCE) playedSeconds += progress;
-      }
-      lastUpdate = now;
-      lastPosition = position;
-      previousState = state;
-
       const duration = parsedDuration || song.length || 0;
-      if (state === 'playing' && currentInstance !== playbackInstance) {
-        currentInstance = playbackInstance;
+      const playback = trackPlayback({
+        duration,
+        instance: playbackInstance,
+        now: performance.now(),
+        position,
+        state,
+      });
+      if (playback.started) {
         startedAt = Math.floor(Date.now() / 1000);
-        playedSeconds = 0;
-        scrobbled = false;
         void request('/api/lastfm/now-playing', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -57,14 +39,8 @@ export const LastFMScrobbler = () => {
         });
       }
 
-      if (
-        currentInstance !== playbackInstance ||
-        scrobbled ||
-        duration <= 30 ||
-        playedSeconds < Math.min(240, duration / 2)
-      )
-        return;
-      scrobbled = true;
+      if (!playback.shouldScrobble || scrobbledInstances.current.get(lastFM.username) === playbackInstance) return;
+      scrobbledInstances.current.set(lastFM.username, playbackInstance);
       void request('/api/lastfm/scrobble', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -83,7 +59,7 @@ export const LastFMScrobbler = () => {
 
     sync(usePlayerStore.getState());
     return usePlayerStore.subscribe(sync);
-  }, [lastFM?.connected]);
+  }, [lastFM?.connected, lastFM?.username]);
 
   return null;
 };

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -11,16 +11,27 @@ export const LastFMScrobbler = () => {
 
     let currentInstance = -1;
     let startedAt = 0;
+    let playedSeconds = 0;
+    let lastUpdate = Date.now();
+    let previousState: ReturnType<typeof usePlayerStore.getState>['state'] = 'stopped';
     let scrobbled = false;
 
     const sync = (player: ReturnType<typeof usePlayerStore.getState>) => {
-      const { song, state, position, parsedDuration, playbackInstance } = player;
+      const { song, state, parsedDuration, playbackInstance } = player;
       if (!song?.artist || !song.title) return;
+
+      const now = Date.now();
+      if (currentInstance === playbackInstance && previousState === 'playing') {
+        playedSeconds += (now - lastUpdate) / 1000;
+      }
+      lastUpdate = now;
+      previousState = state;
 
       const duration = parsedDuration || song.length || 0;
       if (state === 'playing' && currentInstance !== playbackInstance) {
         currentInstance = playbackInstance;
         startedAt = Math.floor(Date.now() / 1000);
+        playedSeconds = 0;
         scrobbled = false;
         void request('/api/lastfm/now-playing', {
           method: 'POST',
@@ -29,7 +40,12 @@ export const LastFMScrobbler = () => {
         }).catch(() => undefined);
       }
 
-      if (currentInstance !== playbackInstance || scrobbled || duration < 30 || position < Math.min(240, duration / 2))
+      if (
+        currentInstance !== playbackInstance ||
+        scrobbled ||
+        duration < 30 ||
+        playedSeconds < Math.min(240, duration / 2)
+      )
         return;
       scrobbled = true;
       void request('/api/lastfm/scrobble', {

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -9,7 +9,8 @@ export const LastFMScrobbler = () => {
   useEffect(() => {
     if (!lastFM?.connected) return;
 
-    let currentInstance = -1;
+    const ignoredInstance = usePlayerStore.getState().playbackInstance;
+    let currentInstance = ignoredInstance;
     let startedAt = 0;
     let playedSeconds = 0;
     let lastUpdate = Date.now();
@@ -21,6 +22,11 @@ export const LastFMScrobbler = () => {
       if (!song?.artist || !song.title) return;
 
       const now = Date.now();
+      if (playbackInstance === ignoredInstance) {
+        lastUpdate = now;
+        previousState = state;
+        return;
+      }
       if (currentInstance === playbackInstance && previousState === 'playing') {
         playedSeconds += (now - lastUpdate) / 1000;
       }

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -7,7 +7,7 @@ import { createLastFMPlaybackTracker } from 'utils/LastFMPlayback';
 
 export const LastFMScrobbler = () => {
   const { data: lastFM } = useLastFM();
-  const scrobbledPlaybackCounts = useRef(new Map<string, number>());
+  const scrobbledPlaybackCount = useRef<number | undefined>(undefined);
 
   useEffect(() => {
     if (!lastFM?.connected) return;
@@ -38,15 +38,19 @@ export const LastFMScrobbler = () => {
           body: JSON.stringify({ artist: song.artist, track: song.title, album: song.album, duration }),
         }).catch((error: unknown) => {
           console.error(`Could not update Last.fm now playing for ${song.artist} — ${song.title}`, error);
-          if (error instanceof ApiError && error.status === 409) void mutate('/api/lastfm');
+
+          if (error instanceof ApiError && error.status === 409) {
+            // Refresh connection state when the Last.fm session expires.
+            void mutate('/api/lastfm');
+          }
         });
       }
 
-      if (!playback.shouldScrobble || scrobbledPlaybackCounts.current.get(lastFM.username) === playbackCount) {
+      if (!playback.shouldScrobble || scrobbledPlaybackCount.current === playbackCount) {
         return;
       }
 
-      scrobbledPlaybackCounts.current.set(lastFM.username, playbackCount);
+      scrobbledPlaybackCount.current = playbackCount;
 
       void request('/api/lastfm/scrobble', {
         method: 'POST',
@@ -60,7 +64,11 @@ export const LastFMScrobbler = () => {
         }),
       }).catch((error: unknown) => {
         console.error(`Could not scrobble ${song.artist} — ${song.title}`, error);
-        if (error instanceof ApiError && error.status === 409) void mutate('/api/lastfm');
+
+        if (error instanceof ApiError && error.status === 409) {
+          // Refresh connection state when the Last.fm session expires.
+          void mutate('/api/lastfm');
+        }
       });
     };
 
@@ -69,7 +77,7 @@ export const LastFMScrobbler = () => {
 
     // Continuously sync playback state when state in store updates
     return usePlayerStore.subscribe(sync);
-  }, [lastFM?.connected, lastFM?.username]);
+  }, [lastFM?.connected]);
 
   return null;
 };

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -20,6 +20,7 @@ export const LastFMScrobbler = () => {
       if (!song?.artist || !song.title) return;
 
       const duration = parsedDuration || song.length || 0;
+
       const playback = trackPlayback({
         duration,
         instance: playbackInstance,
@@ -27,6 +28,7 @@ export const LastFMScrobbler = () => {
         position,
         state,
       });
+
       if (playback.started) {
         startedAt = Math.floor(Date.now() / 1000);
         void request('/api/lastfm/now-playing', {
@@ -39,8 +41,12 @@ export const LastFMScrobbler = () => {
         });
       }
 
-      if (!playback.shouldScrobble || scrobbledInstances.current.get(lastFM.username) === playbackInstance) return;
+      if (!playback.shouldScrobble || scrobbledInstances.current.get(lastFM.username) === playbackInstance) {
+        return;
+      }
+
       scrobbledInstances.current.set(lastFM.username, playbackInstance);
+
       void request('/api/lastfm/scrobble', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -57,7 +63,10 @@ export const LastFMScrobbler = () => {
       });
     };
 
+    // Set initial state
     sync(usePlayerStore.getState());
+    
+    // Continously sync playback state when state in store updates
     return usePlayerStore.subscribe(sync);
   }, [lastFM?.connected, lastFM?.username]);
 

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -60,7 +60,7 @@ export const LastFMScrobbler = () => {
       if (
         currentInstance !== playbackInstance ||
         scrobbled ||
-        duration < 30 ||
+        duration <= 30 ||
         playedSeconds < Math.min(240, duration / 2)
       )
         return;

--- a/frontend/src/components/LastFMScrobbler.tsx
+++ b/frontend/src/components/LastFMScrobbler.tsx
@@ -1,49 +1,52 @@
 import { useLastFM } from 'hooks/swr';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { usePlayerStore } from 'store';
 import { request } from 'utils/api';
 
 export const LastFMScrobbler = () => {
   const { data: lastFM } = useLastFM();
-  const song = usePlayerStore((state) => state.song);
-  const state = usePlayerStore((state) => state.state);
-  const position = usePlayerStore((state) => state.position);
-  const duration = usePlayerStore((state) => state.parsedDuration || state.song?.length || 0);
-  const startedAt = useRef(0);
-  const announced = useRef('');
-  const scrobbled = useRef('');
-
-  const id = song?.path ?? '';
 
   useEffect(() => {
-    if (!lastFM?.connected || !song || state !== 'playing' || announced.current === id) return;
-    announced.current = id;
-    scrobbled.current = '';
-    startedAt.current = Math.floor(Date.now() / 1000);
-    void request('/api/lastfm/now-playing', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ artist: song.artist, track: song.title, album: song.album, duration }),
-    }).catch(() => undefined);
-  }, [duration, id, lastFM?.connected, song, state]);
+    if (!lastFM?.connected) return;
 
-  useEffect(() => {
-    if (!lastFM?.connected || !song || !song.artist || !song.title || duration < 30 || scrobbled.current === id) return;
-    const threshold = Math.min(240, duration / 2);
-    if (!threshold || position < threshold) return;
-    scrobbled.current = id;
-    void request('/api/lastfm/scrobble', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        artist: song.artist,
-        track: song.title,
-        album: song.album,
-        duration,
-        timestamp: startedAt.current,
-      }),
-    }).catch(() => undefined);
-  }, [duration, id, lastFM?.connected, position, song]);
+    let currentTrack = '';
+    let startedAt = 0;
+    let scrobbled = false;
+
+    const sync = (player: ReturnType<typeof usePlayerStore.getState>) => {
+      const { song, state, position, parsedDuration } = player;
+      if (!song?.artist || !song.title) return;
+
+      const duration = parsedDuration || song.length || 0;
+      if (state === 'playing' && currentTrack !== song.path) {
+        currentTrack = song.path;
+        startedAt = Math.floor(Date.now() / 1000);
+        scrobbled = false;
+        void request('/api/lastfm/now-playing', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ artist: song.artist, track: song.title, album: song.album, duration }),
+        }).catch(() => undefined);
+      }
+
+      if (currentTrack !== song.path || scrobbled || duration < 30 || position < Math.min(240, duration / 2)) return;
+      scrobbled = true;
+      void request('/api/lastfm/scrobble', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          artist: song.artist,
+          track: song.title,
+          album: song.album,
+          duration,
+          timestamp: startedAt,
+        }),
+      }).catch(() => undefined);
+    };
+
+    sync(usePlayerStore.getState());
+    return usePlayerStore.subscribe(sync);
+  }, [lastFM?.connected]);
 
   return null;
 };

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,14 +1,57 @@
+import { useLastFM, useSession } from 'hooks/swr';
 import { useState } from 'react';
-
-import { useSession } from 'hooks/swr';
-
-import { PasswordChangeModal } from './PasswordChangeModal';
+import { mutate } from 'swr';
+import { request } from 'utils/api';
 import { Button } from './common/Button';
 import { Modal } from './common/Modal';
+import { PasswordChangeModal } from './PasswordChangeModal';
 
 export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
   const { user } = useSession();
   const [changingPassword, setChangingPassword] = useState(false);
+  const { data: lastFM } = useLastFM();
+  const [pending, setPending] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  const connect = async () => {
+    setBusy(true);
+    setError('');
+    try {
+      const { url } = await request<{ url: string }>('/api/lastfm/connect', { method: 'POST' });
+      window.open(url, 'lastfm-auth', 'popup,width=900,height=700');
+      setPending(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not connect to Last.fm');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const complete = async () => {
+    setBusy(true);
+    setError('');
+    try {
+      await request('/api/lastfm/complete', { method: 'POST' });
+      setPending(false);
+      await mutate('/api/lastfm');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not finish the Last.fm connection');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const disconnect = async () => {
+    setBusy(true);
+    setError('');
+    try {
+      await request('/api/lastfm', { method: 'DELETE' });
+      await mutate('/api/lastfm');
+    } finally {
+      setBusy(false);
+    }
+  };
 
   if (changingPassword) {
     return <PasswordChangeModal onClose={onClose} />;
@@ -41,19 +84,43 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
       <section>
         <label>Last.fm</label>
         <div className="form-field">
-          <button className="btn btn-lastfm not-ok" id="lastfm-connect" tabIndex={4}>
-            Connect to Last.fm
-          </button>
-          <p className="connecting" style={{ display: 'none' }}>
-            <i className="icon-loading" />
-            Connecting&hellip;
-          </p>
-          <p className="ok" style={{ display: 'none' }}>
-            Connected
-            <button className="btn" id="lastfm-disconnect" tabIndex={4}>
-              Remove connection
-            </button>
-          </p>
+          {!lastFM?.configured ? <p>Set LASTFM_API_KEY and LASTFM_API_SECRET to enable Last.fm.</p> : null}
+          {lastFM?.configured && !lastFM.connected && !pending ? (
+            <Button
+              variant="secondary"
+              className="btn btn-lastfm not-ok"
+              id="lastfm-connect"
+              tabIndex={4}
+              disabled={busy}
+              onClick={connect}
+            >
+              Connect to Last.fm
+            </Button>
+          ) : null}
+          {pending ? (
+            <p>
+              Authorize Beatstream in the opened window, then{' '}
+              <Button variant="secondary" className="btn" tabIndex={4} disabled={busy} onClick={complete}>
+                Finish connection
+              </Button>
+            </p>
+          ) : null}
+          {lastFM?.connected ? (
+            <p className="ok">
+              Connected as {lastFM.username}{' '}
+              <Button
+                variant="secondary"
+                className="btn"
+                id="lastfm-disconnect"
+                tabIndex={4}
+                disabled={busy}
+                onClick={disconnect}
+              >
+                Remove connection
+              </Button>
+            </p>
+          ) : null}
+          {error ? <p>{error}</p> : null}
         </div>
       </section>
       <div className="right">

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -15,13 +15,19 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
   const [error, setError] = useState('');
 
   const connect = async () => {
+    const popup = window.open('', 'lastfm-auth', 'popup,width=900,height=700');
+    if (!popup) {
+      setError('Allow popups to connect to Last.fm');
+      return;
+    }
     setBusy(true);
     setError('');
     try {
       const { url } = await request<{ url: string }>('/api/lastfm/connect', { method: 'POST' });
-      window.open(url, 'lastfm-auth', 'popup,width=900,height=700');
+      popup.location.href = url;
       setPending(true);
     } catch (err) {
+      popup.close();
       setError(err instanceof Error ? err.message : 'Could not connect to Last.fm');
     } finally {
       setBusy(false);

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -11,23 +11,23 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
   const [changingPassword, setChangingPassword] = useState(false);
   const { data: lastFM } = useLastFM();
   const [busy, setBusy] = useState(false);
-  const [error, setError] = useState('');
+  const [lastFMError, setLastFMError] = useState('');
 
   const connect = async () => {
     const popup = window.open('', 'lastfm-auth', 'popup,width=900,height=700');
     if (!popup) {
-      setError('Allow popups to connect to Last.fm');
+      setLastFMError('Allow popups to connect to Last.fm');
       return;
     }
     setBusy(true);
-    setError('');
+    setLastFMError('');
     try {
       const { url } = await request<{ url: string }>('/api/lastfm/connect', { method: 'POST' });
       popup.location.href = url;
       await mutate('/api/lastfm');
     } catch (err) {
       popup.close();
-      setError(err instanceof Error ? err.message : 'Could not connect to Last.fm');
+      setLastFMError(err instanceof Error ? err.message : 'Could not connect to Last.fm');
     } finally {
       setBusy(false);
     }
@@ -35,12 +35,12 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
 
   const complete = async () => {
     setBusy(true);
-    setError('');
+    setLastFMError('');
     try {
       await request('/api/lastfm/complete', { method: 'POST' });
       await mutate('/api/lastfm');
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not finish the Last.fm connection');
+      setLastFMError(err instanceof Error ? err.message : 'Could not finish the Last.fm connection');
     } finally {
       setBusy(false);
     }
@@ -48,12 +48,12 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
 
   const disconnect = async () => {
     setBusy(true);
-    setError('');
+    setLastFMError('');
     try {
       await request('/api/lastfm', { method: 'DELETE' });
       await mutate('/api/lastfm');
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not disconnect from Last.fm');
+      setLastFMError(err instanceof Error ? err.message : 'Could not disconnect from Last.fm');
     } finally {
       setBusy(false);
     }
@@ -130,7 +130,7 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
               </Button>
             </p>
           ) : null}
-          {error ? <p>{error}</p> : null}
+          {lastFMError ? <p>{lastFMError}</p> : null}
         </div>
       </section>
       <div className="right">

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -10,7 +10,6 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
   const { user } = useSession();
   const [changingPassword, setChangingPassword] = useState(false);
   const { data: lastFM } = useLastFM();
-  const [pending, setPending] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
 
@@ -25,7 +24,7 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
     try {
       const { url } = await request<{ url: string }>('/api/lastfm/connect', { method: 'POST' });
       popup.location.href = url;
-      setPending(true);
+      await mutate('/api/lastfm');
     } catch (err) {
       popup.close();
       setError(err instanceof Error ? err.message : 'Could not connect to Last.fm');
@@ -39,7 +38,6 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
     setError('');
     try {
       await request('/api/lastfm/complete', { method: 'POST' });
-      setPending(false);
       await mutate('/api/lastfm');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not finish the Last.fm connection');
@@ -93,7 +91,7 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
         <label>Last.fm</label>
         <div className="form-field">
           {!lastFM?.configured ? <p>Set LASTFM_API_KEY and LASTFM_API_SECRET to enable Last.fm.</p> : null}
-          {lastFM?.configured && !lastFM.connected && !pending ? (
+          {lastFM?.configured && !lastFM.connected && !lastFM.pending ? (
             <Button
               variant="secondary"
               className="btn btn-lastfm not-ok"
@@ -105,11 +103,15 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
               Connect to Last.fm
             </Button>
           ) : null}
-          {pending ? (
+          {lastFM?.pending ? (
             <p>
               Authorize Beatstream in the opened window, then{' '}
               <Button variant="secondary" className="btn" tabIndex={4} disabled={busy} onClick={complete}>
                 Finish connection
+              </Button>{' '}
+              or{' '}
+              <Button variant="secondary" className="btn" tabIndex={4} disabled={busy} onClick={connect}>
+                Restart authorization
               </Button>
             </p>
           ) : null}

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -54,6 +54,8 @@ export const SettingsModal = ({ onClose }: { onClose: () => void }) => {
     try {
       await request('/api/lastfm', { method: 'DELETE' });
       await mutate('/api/lastfm');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not disconnect from Last.fm');
     } finally {
       setBusy(false);
     }

--- a/frontend/src/hooks/swr.ts
+++ b/frontend/src/hooks/swr.ts
@@ -31,3 +31,5 @@ export const useRefreshStatus = () =>
   useApi<{ refreshing: boolean }>('/api/songs/refresh', undefined, {
     refreshInterval: (status) => (status?.refreshing ? 1000 : 0),
   });
+
+export const useLastFM = () => useApi<{ configured: boolean; connected: boolean; username: string }>('/api/lastfm');

--- a/frontend/src/hooks/swr.ts
+++ b/frontend/src/hooks/swr.ts
@@ -32,4 +32,5 @@ export const useRefreshStatus = () =>
     refreshInterval: (status) => (status?.refreshing ? 1000 : 0),
   });
 
-export const useLastFM = () => useApi<{ configured: boolean; connected: boolean; username: string }>('/api/lastfm');
+export const useLastFM = () =>
+  useApi<{ configured: boolean; connected: boolean; pending: boolean; username: string }>('/api/lastfm');

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -25,7 +25,7 @@ interface PlayerState {
   position: number;
 
   /** Increments whenever a new track playback starts, including repeats */
-  playbackInstance: number;
+  playbackCount: number;
 
   /** Repeat & shuffle states */
   repeat: boolean;
@@ -106,7 +106,7 @@ export const usePlayerStore = create<PlayerState>()(
       (set) => ({
         appNavWidth: DEFAULT_APP_NAV_WIDTH,
         parsedDuration: 0,
-        playbackInstance: 0,
+        playbackCount: 0,
         playlist: [] as Song[],
         position: 0,
         repeat: false,
@@ -175,7 +175,7 @@ export const usePlayerStore = create<PlayerState>()(
 
             return {
               parsedDuration: 0,
-              playbackInstance: state.playbackInstance + 1,
+              playbackCount: state.playbackCount + 1,
               position: 0,
               song,
               state: 'playing',
@@ -198,8 +198,6 @@ export const usePlayerStore = create<PlayerState>()(
               return {};
             }
 
-            const isResume = state.state === 'paused';
-
             AppAudio.playSong(song.path);
 
             // if we were playing something before, play & seek to previous position
@@ -208,7 +206,7 @@ export const usePlayerStore = create<PlayerState>()(
             }
 
             return {
-              playbackInstance: isResume ? state.playbackInstance : state.playbackInstance + 1,
+              playbackCount: state.state === 'paused' ? state.playbackCount : state.playbackCount + 1,
               song,
               state: 'playing',
             };
@@ -338,7 +336,7 @@ function changeSong(direction: -1 | 1, { force } = { force: false }): (state: Pl
 
       return {
         parsedDuration: 0,
-        playbackInstance: state.playbackInstance + 1,
+        playbackCount: state.playbackCount + 1,
         position: 0,
         song: nextSong,
         ...newHistory,

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -24,7 +24,7 @@ interface PlayerState {
   /** Current song position in seconds */
   position: number;
 
-  /** Increments whenever a new track playback starts, including repeats */
+  /** Increments whenever a new track playback starts, including repeats. Used by LastFM to track unique plays. */
   playbackCount: number;
 
   /** Repeat & shuffle states */

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -198,6 +198,8 @@ export const usePlayerStore = create<PlayerState>()(
               return {};
             }
 
+            const isResume = state.state === 'paused';
+
             AppAudio.playSong(song.path);
 
             // if we were playing something before, play & seek to previous position
@@ -206,7 +208,7 @@ export const usePlayerStore = create<PlayerState>()(
             }
 
             return {
-              playbackInstance: state.song ? state.playbackInstance : state.playbackInstance + 1,
+              playbackInstance: isResume ? state.playbackInstance : state.playbackInstance + 1,
               song,
               state: 'playing',
             };

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -24,6 +24,9 @@ interface PlayerState {
   /** Current song position in seconds */
   position: number;
 
+  /** Increments whenever a new track playback starts, including repeats */
+  playbackInstance: number;
+
   /** Repeat & shuffle states */
   repeat: boolean;
   shuffle: boolean;
@@ -103,6 +106,7 @@ export const usePlayerStore = create<PlayerState>()(
       (set) => ({
         appNavWidth: DEFAULT_APP_NAV_WIDTH,
         parsedDuration: 0,
+        playbackInstance: 0,
         playlist: [] as Song[],
         position: 0,
         repeat: false,
@@ -171,6 +175,7 @@ export const usePlayerStore = create<PlayerState>()(
 
             return {
               parsedDuration: 0,
+              playbackInstance: state.playbackInstance + 1,
               position: 0,
               song,
               state: 'playing',
@@ -201,6 +206,7 @@ export const usePlayerStore = create<PlayerState>()(
             }
 
             return {
+              playbackInstance: state.song ? state.playbackInstance : state.playbackInstance + 1,
               song,
               state: 'playing',
             };
@@ -330,6 +336,7 @@ function changeSong(direction: -1 | 1, { force } = { force: false }): (state: Pl
 
       return {
         parsedDuration: 0,
+        playbackInstance: state.playbackInstance + 1,
         position: 0,
         song: nextSong,
         ...newHistory,

--- a/frontend/src/utils/LastFMPlayback.ts
+++ b/frontend/src/utils/LastFMPlayback.ts
@@ -2,39 +2,46 @@ const PLAYBACK_CLOCK_TOLERANCE = 1;
 
 type PlaybackUpdate = {
   duration: number;
-  instance: number;
   now: number;
+  playbackCount: number;
   position: number;
   state: 'playing' | 'paused' | 'stopped';
 };
 
 export const createLastFMPlaybackTracker = () => {
-  let currentInstance: number | undefined;
+  let currentPlaybackCount: number | undefined;
   let lastPosition = 0;
   let lastUpdate = 0;
   let playedSeconds = 0;
   let previousState: PlaybackUpdate['state'] = 'stopped';
   let scrobbled = false;
 
-  return ({ duration, instance, now, position, state }: PlaybackUpdate) => {
-    if (currentInstance === instance && previousState === 'playing') {
+  return ({ duration, now, playbackCount, position, state }: PlaybackUpdate) => {
+    if (currentPlaybackCount === playbackCount && previousState === 'playing') {
       const progress = position - lastPosition;
       const elapsed = (now - lastUpdate) / 1000;
+
       if (progress > 0 && progress <= elapsed + PLAYBACK_CLOCK_TOLERANCE) playedSeconds += progress;
     }
+
     lastUpdate = now;
     lastPosition = position;
     previousState = state;
 
-    const started = state === 'playing' && currentInstance !== instance;
+    const started = state === 'playing' && currentPlaybackCount !== playbackCount;
+
     if (started) {
-      currentInstance = instance;
+      currentPlaybackCount = playbackCount;
       playedSeconds = 0;
       scrobbled = false;
     }
 
     const shouldScrobble =
-      currentInstance === instance && !scrobbled && duration > 30 && playedSeconds >= Math.min(240, duration / 2);
+      currentPlaybackCount === playbackCount &&
+      !scrobbled &&
+      duration > 30 &&
+      playedSeconds >= Math.min(240, duration / 2);
+
     if (shouldScrobble) scrobbled = true;
 
     return { shouldScrobble, started };

--- a/frontend/src/utils/LastFMPlayback.ts
+++ b/frontend/src/utils/LastFMPlayback.ts
@@ -1,0 +1,42 @@
+const PLAYBACK_CLOCK_TOLERANCE = 1;
+
+type PlaybackUpdate = {
+  duration: number;
+  instance: number;
+  now: number;
+  position: number;
+  state: 'playing' | 'paused' | 'stopped';
+};
+
+export const createLastFMPlaybackTracker = () => {
+  let currentInstance: number | undefined;
+  let lastPosition = 0;
+  let lastUpdate = 0;
+  let playedSeconds = 0;
+  let previousState: PlaybackUpdate['state'] = 'stopped';
+  let scrobbled = false;
+
+  return ({ duration, instance, now, position, state }: PlaybackUpdate) => {
+    if (currentInstance === instance && previousState === 'playing') {
+      const progress = position - lastPosition;
+      const elapsed = (now - lastUpdate) / 1000;
+      if (progress > 0 && progress <= elapsed + PLAYBACK_CLOCK_TOLERANCE) playedSeconds += progress;
+    }
+    lastUpdate = now;
+    lastPosition = position;
+    previousState = state;
+
+    const started = state === 'playing' && currentInstance !== instance;
+    if (started) {
+      currentInstance = instance;
+      playedSeconds = 0;
+      scrobbled = false;
+    }
+
+    const shouldScrobble =
+      currentInstance === instance && !scrobbled && duration > 30 && playedSeconds >= Math.min(240, duration / 2);
+    if (shouldScrobble) scrobbled = true;
+
+    return { shouldScrobble, started };
+  };
+};

--- a/frontend/unit/LastFMPlayback.spec.ts
+++ b/frontend/unit/LastFMPlayback.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+
+import { createLastFMPlaybackTracker } from '../src/utils/LastFMPlayback';
+
+const update = (
+  tracker: ReturnType<typeof createLastFMPlaybackTracker>,
+  position: number,
+  now: number,
+  overrides: Partial<Parameters<typeof tracker>[0]> = {},
+) => tracker({ duration: 100, instance: 1, now, position, state: 'playing', ...overrides });
+
+test('counts playback progress but not seeks', () => {
+  const tracker = createLastFMPlaybackTracker();
+  expect(update(tracker, 0, 0).started).toBe(true);
+  update(tracker, 10, 10_000);
+  update(tracker, 80, 10_100);
+  update(tracker, 5, 11_000);
+  expect(update(tracker, 44, 50_000).shouldScrobble).toBe(false);
+  expect(update(tracker, 45, 51_000).shouldScrobble).toBe(true);
+});
+
+test('excludes paused time', () => {
+  const tracker = createLastFMPlaybackTracker();
+  update(tracker, 0, 0, { duration: 60 });
+  update(tracker, 12, 12_000, { duration: 60, state: 'paused' });
+  update(tracker, 12, 112_000, { duration: 60, state: 'paused' });
+  update(tracker, 12, 112_000, { duration: 60 });
+  expect(update(tracker, 29, 129_000, { duration: 60 }).shouldScrobble).toBe(false);
+  expect(update(tracker, 30, 130_000, { duration: 60 }).shouldScrobble).toBe(true);
+});
+
+test('distinguishes repeated plays of the same track', () => {
+  const tracker = createLastFMPlaybackTracker();
+  update(tracker, 0, 0);
+  expect(update(tracker, 50, 50_000).shouldScrobble).toBe(true);
+  expect(update(tracker, 0, 51_000, { instance: 2 }).started).toBe(true);
+  expect(update(tracker, 49, 100_000, { instance: 2 }).shouldScrobble).toBe(false);
+  expect(update(tracker, 50, 101_000, { instance: 2 }).shouldScrobble).toBe(true);
+});
+
+test('requires tracks to be longer than thirty seconds', () => {
+  const tracker = createLastFMPlaybackTracker();
+  update(tracker, 0, 0, { duration: 30 });
+  expect(update(tracker, 30, 30_000, { duration: 30 }).shouldScrobble).toBe(false);
+  update(tracker, 0, 31_000, { duration: 31, instance: 2 });
+  expect(update(tracker, 15.5, 46_500, { duration: 31, instance: 2 }).shouldScrobble).toBe(true);
+});
+
+test('caps the threshold at four minutes', () => {
+  const tracker = createLastFMPlaybackTracker();
+  update(tracker, 0, 0, { duration: 1_000 });
+  expect(update(tracker, 239, 239_000, { duration: 1_000 }).shouldScrobble).toBe(false);
+  expect(update(tracker, 240, 240_000, { duration: 1_000 }).shouldScrobble).toBe(true);
+});
+
+test('starts counting when Last.fm becomes available during playback', () => {
+  const tracker = createLastFMPlaybackTracker();
+  const initial = update(tracker, 100, 5_000);
+  expect(initial).toEqual({ shouldScrobble: false, started: true });
+  expect(update(tracker, 150, 55_000).shouldScrobble).toBe(true);
+});
+
+test('waits for restored playback to resume', () => {
+  const tracker = createLastFMPlaybackTracker();
+  expect(update(tracker, 40, 5_000, { state: 'paused' }).started).toBe(false);
+  expect(update(tracker, 40, 6_000).started).toBe(true);
+  expect(update(tracker, 90, 56_000).shouldScrobble).toBe(true);
+});

--- a/frontend/unit/LastFMPlayback.spec.ts
+++ b/frontend/unit/LastFMPlayback.spec.ts
@@ -7,10 +7,11 @@ const update = (
   position: number,
   now: number,
   overrides: Partial<Parameters<typeof tracker>[0]> = {},
-) => tracker({ duration: 100, instance: 1, now, position, state: 'playing', ...overrides });
+) => tracker({ duration: 100, now, playbackCount: 1, position, state: 'playing', ...overrides });
 
 test('counts playback progress but not seeks', () => {
   const tracker = createLastFMPlaybackTracker();
+
   expect(update(tracker, 0, 0).started).toBe(true);
   update(tracker, 10, 10_000);
   update(tracker, 80, 10_100);
@@ -21,6 +22,7 @@ test('counts playback progress but not seeks', () => {
 
 test('excludes paused time', () => {
   const tracker = createLastFMPlaybackTracker();
+
   update(tracker, 0, 0, { duration: 60 });
   update(tracker, 12, 12_000, { duration: 60, state: 'paused' });
   update(tracker, 12, 112_000, { duration: 60, state: 'paused' });
@@ -31,23 +33,26 @@ test('excludes paused time', () => {
 
 test('distinguishes repeated plays of the same track', () => {
   const tracker = createLastFMPlaybackTracker();
+
   update(tracker, 0, 0);
   expect(update(tracker, 50, 50_000).shouldScrobble).toBe(true);
-  expect(update(tracker, 0, 51_000, { instance: 2 }).started).toBe(true);
-  expect(update(tracker, 49, 100_000, { instance: 2 }).shouldScrobble).toBe(false);
-  expect(update(tracker, 50, 101_000, { instance: 2 }).shouldScrobble).toBe(true);
+  expect(update(tracker, 0, 51_000, { playbackCount: 2 }).started).toBe(true);
+  expect(update(tracker, 49, 100_000, { playbackCount: 2 }).shouldScrobble).toBe(false);
+  expect(update(tracker, 50, 101_000, { playbackCount: 2 }).shouldScrobble).toBe(true);
 });
 
 test('requires tracks to be longer than thirty seconds', () => {
   const tracker = createLastFMPlaybackTracker();
+
   update(tracker, 0, 0, { duration: 30 });
   expect(update(tracker, 30, 30_000, { duration: 30 }).shouldScrobble).toBe(false);
-  update(tracker, 0, 31_000, { duration: 31, instance: 2 });
-  expect(update(tracker, 15.5, 46_500, { duration: 31, instance: 2 }).shouldScrobble).toBe(true);
+  update(tracker, 0, 31_000, { duration: 31, playbackCount: 2 });
+  expect(update(tracker, 15.5, 46_500, { duration: 31, playbackCount: 2 }).shouldScrobble).toBe(true);
 });
 
 test('caps the threshold at four minutes', () => {
   const tracker = createLastFMPlaybackTracker();
+
   update(tracker, 0, 0, { duration: 1_000 });
   expect(update(tracker, 239, 239_000, { duration: 1_000 }).shouldScrobble).toBe(false);
   expect(update(tracker, 240, 240_000, { duration: 1_000 }).shouldScrobble).toBe(true);
@@ -55,13 +60,16 @@ test('caps the threshold at four minutes', () => {
 
 test('starts counting when Last.fm becomes available during playback', () => {
   const tracker = createLastFMPlaybackTracker();
+
   const initial = update(tracker, 100, 5_000);
+
   expect(initial).toEqual({ shouldScrobble: false, started: true });
   expect(update(tracker, 150, 55_000).shouldScrobble).toBe(true);
 });
 
 test('waits for restored playback to resume', () => {
   const tracker = createLastFMPlaybackTracker();
+
   expect(update(tracker, 40, 5_000, { state: 'paused' }).started).toBe(false);
   expect(update(tracker, 40, 6_000).started).toBe(true);
   expect(update(tracker, 90, 56_000).shouldScrobble).toBe(true);

--- a/lastfm.go
+++ b/lastfm.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -28,11 +29,11 @@ type lastFMResponse struct {
 }
 
 type lastFMTrack struct {
-	Artist    string `json:"artist"`
-	Track     string `json:"track"`
-	Album     string `json:"album,omitempty"`
-	Duration  int    `json:"duration,omitempty"`
-	Timestamp int64  `json:"timestamp,omitempty"`
+	Artist    string  `json:"artist"`
+	Track     string  `json:"track"`
+	Album     string  `json:"album,omitempty"`
+	Duration  float64 `json:"duration,omitempty"`
+	Timestamp int64   `json:"timestamp,omitempty"`
 }
 
 func lastFMCredentials() (string, string, error) {
@@ -169,7 +170,7 @@ func lastFMTrackHandler(method string) http.HandlerFunc {
 			values.Set("album", track.Album)
 		}
 		if track.Duration > 0 {
-			values.Set("duration", fmt.Sprint(track.Duration))
+			values.Set("duration", fmt.Sprint(math.Round(track.Duration)))
 		}
 		if method == "track.scrobble" {
 			if track.Timestamp == 0 {

--- a/lastfm.go
+++ b/lastfm.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+var lastFMAPIURL = "https://ws.audioscrobbler.com/2.0/"
+var lastFMHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+type lastFMResponse struct {
+	Token   string `json:"token"`
+	Session struct {
+		Name string `json:"name"`
+		Key  string `json:"key"`
+	} `json:"session"`
+	Error   int    `json:"error"`
+	Message string `json:"message"`
+}
+
+type lastFMTrack struct {
+	Artist    string `json:"artist"`
+	Track     string `json:"track"`
+	Album     string `json:"album,omitempty"`
+	Duration  int    `json:"duration,omitempty"`
+	Timestamp int64  `json:"timestamp,omitempty"`
+}
+
+func lastFMCredentials() (string, string, error) {
+	key, secret := os.Getenv("LASTFM_API_KEY"), os.Getenv("LASTFM_API_SECRET")
+	if key == "" || secret == "" {
+		return "", "", errors.New("Last.fm is not configured")
+	}
+	return key, secret, nil
+}
+
+func lastFMSign(values url.Values, secret string) string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if key != "format" && key != "callback" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	var input strings.Builder
+	for _, key := range keys {
+		input.WriteString(key)
+		input.WriteString(values.Get(key))
+	}
+	input.WriteString(secret)
+	sum := md5.Sum([]byte(input.String())) // Last.fm's required API signature algorithm.
+	return hex.EncodeToString(sum[:])
+}
+
+func lastFMCall(values url.Values) (*lastFMResponse, error) {
+	key, secret, err := lastFMCredentials()
+	if err != nil {
+		return nil, err
+	}
+	values.Set("api_key", key)
+	values.Set("api_sig", lastFMSign(values, secret))
+	values.Set("format", "json")
+	response, err := lastFMHTTPClient.PostForm(lastFMAPIURL, values)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	var result lastFMResponse
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	if result.Error != 0 {
+		return nil, fmt.Errorf("Last.fm: %s", result.Message)
+	}
+	return &result, nil
+}
+
+func lastFMStatusHandler(w http.ResponseWriter, r *http.Request) {
+	usersMutex.Lock()
+	defer usersMutex.Unlock()
+	user := currentUser(r)
+	if user == nil {
+		http.Error(w, "User not found", http.StatusNotFound)
+		return
+	}
+	respondJSON(w, map[string]any{"configured": os.Getenv("LASTFM_API_KEY") != "" && os.Getenv("LASTFM_API_SECRET") != "", "connected": user.LastFMSession != "", "username": user.LastFMUsername})
+}
+
+func lastFMConnectHandler(w http.ResponseWriter, r *http.Request) {
+	result, err := lastFMCall(url.Values{"method": {"auth.getToken"}})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	usersMutex.Lock()
+	defer usersMutex.Unlock()
+	user := currentUser(r)
+	if user == nil {
+		http.Error(w, "User not found", http.StatusNotFound)
+		return
+	}
+	user.LastFMToken = result.Token
+	if err := saveUsersUnlocked(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	respondJSON(w, map[string]string{"url": "https://www.last.fm/api/auth/?api_key=" + url.QueryEscape(os.Getenv("LASTFM_API_KEY")) + "&token=" + url.QueryEscape(result.Token)})
+}
+
+func lastFMCompleteHandler(w http.ResponseWriter, r *http.Request) {
+	usersMutex.Lock()
+	user := currentUser(r)
+	if user == nil || user.LastFMToken == "" {
+		usersMutex.Unlock()
+		http.Error(w, "No Last.fm connection is pending", http.StatusBadRequest)
+		return
+	}
+	token := user.LastFMToken
+	usersMutex.Unlock()
+	result, err := lastFMCall(url.Values{"method": {"auth.getSession"}, "token": {token}})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	usersMutex.Lock()
+	defer usersMutex.Unlock()
+	user = currentUser(r)
+	if user == nil || user.LastFMToken != token {
+		http.Error(w, "Last.fm connection changed", http.StatusConflict)
+		return
+	}
+	user.LastFMUsername, user.LastFMSession, user.LastFMToken = result.Session.Name, result.Session.Key, ""
+	if err := saveUsersUnlocked(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	respondJSON(w, map[string]any{"connected": true, "username": user.LastFMUsername})
+}
+
+func lastFMDisconnectHandler(w http.ResponseWriter, r *http.Request) {
+	usersMutex.Lock()
+	defer usersMutex.Unlock()
+	user := currentUser(r)
+	if user == nil {
+		http.Error(w, "User not found", http.StatusNotFound)
+		return
+	}
+	user.LastFMUsername, user.LastFMSession, user.LastFMToken = "", "", ""
+	if err := saveUsersUnlocked(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	respondJSON(w, map[string]any{"connected": false})
+}
+
+func lastFMTrackHandler(method string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var track lastFMTrack
+		if err := json.NewDecoder(r.Body).Decode(&track); err != nil || track.Artist == "" || track.Track == "" {
+			http.Error(w, "Artist and track are required", http.StatusBadRequest)
+			return
+		}
+		usersMutex.Lock()
+		user := currentUser(r)
+		if user == nil || user.LastFMSession == "" {
+			usersMutex.Unlock()
+			http.Error(w, "Last.fm is not connected", http.StatusConflict)
+			return
+		}
+		session := user.LastFMSession
+		usersMutex.Unlock()
+		values := url.Values{"method": {method}, "artist": {track.Artist}, "track": {track.Track}, "sk": {session}}
+		if track.Album != "" {
+			values.Set("album", track.Album)
+		}
+		if track.Duration > 0 {
+			values.Set("duration", fmt.Sprint(track.Duration))
+		}
+		if method == "track.scrobble" {
+			if track.Timestamp == 0 {
+				track.Timestamp = time.Now().Unix()
+			}
+			values.Set("timestamp", fmt.Sprint(track.Timestamp))
+		}
+		if _, err := lastFMCall(values); err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		respondJSON(w, map[string]any{})
+	}
+}
+
+var lastFMNowPlayingHandler = lastFMTrackHandler("track.updateNowPlaying")
+var lastFMScrobbleHandler = lastFMTrackHandler("track.scrobble")

--- a/lastfm.go
+++ b/lastfm.go
@@ -179,7 +179,7 @@ func lastFMCompleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	users = updated
-	respondJSON(w, map[string]any{"connected": true, "username": user.LastFMUsername})
+	respondJSON(w, map[string]string{})
 }
 
 func lastFMDisconnectHandler(w http.ResponseWriter, r *http.Request) {
@@ -194,7 +194,7 @@ func lastFMDisconnectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	users = updated
-	respondJSON(w, map[string]any{"connected": false})
+	respondJSON(w, map[string]string{})
 }
 
 func lastFMTrackHandler(method string) http.HandlerFunc {

--- a/lastfm.go
+++ b/lastfm.go
@@ -78,10 +78,16 @@ func lastFMCall(values url.Values) (*lastFMResponse, error) {
 	defer response.Body.Close()
 	var result lastFMResponse
 	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
-		return nil, err
+		if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+			return nil, fmt.Errorf("Last.fm: HTTP %s", response.Status)
+		}
+		return nil, fmt.Errorf("Last.fm: invalid response: %w", err)
 	}
 	if result.Error != 0 {
 		return nil, fmt.Errorf("Last.fm: %s", result.Message)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("Last.fm: HTTP %s", response.Status)
 	}
 	return &result, nil
 }

--- a/lastfm.go
+++ b/lastfm.go
@@ -14,6 +14,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Darep/Beatstream/logger"
 )
 
 var lastFMAPIURL = "https://ws.audioscrobbler.com/2.0/"
@@ -27,6 +29,15 @@ type lastFMResponse struct {
 	} `json:"session"`
 	Error   int    `json:"error"`
 	Message string `json:"message"`
+}
+
+type lastFMError struct {
+	Code    int
+	Message string
+}
+
+func (err *lastFMError) Error() string {
+	return fmt.Sprintf("Last.fm: %s", err.Message)
 }
 
 type lastFMTrack struct {
@@ -84,7 +95,7 @@ func lastFMCall(values url.Values) (*lastFMResponse, error) {
 		return nil, fmt.Errorf("Last.fm: invalid response: %w", err)
 	}
 	if result.Error != 0 {
-		return nil, fmt.Errorf("Last.fm: %s", result.Message)
+		return nil, &lastFMError{Code: result.Error, Message: result.Message}
 	}
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("Last.fm: HTTP %s", response.Status)
@@ -200,6 +211,22 @@ func lastFMTrackHandler(method string) http.HandlerFunc {
 			values.Set("timestamp", fmt.Sprint(track.Timestamp))
 		}
 		if _, err := lastFMCall(values); err != nil {
+			logger.Log.Printf("Last.fm %s failed for %q by %q: %v", method, track.Track, track.Artist, err)
+			var apiErr *lastFMError
+			if errors.As(err, &apiErr) && apiErr.Code == 9 {
+				updated, user := lastFMUpdatedUser(r)
+				if user != nil && user.LastFMSession == session {
+					user.LastFMUsername, user.LastFMSession, user.LastFMToken = "", "", ""
+					if err := saveUsers(updated); err != nil {
+						logger.Log.Printf("Failed to clear invalid Last.fm session: %v", err)
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+					users = updated
+				}
+				http.Error(w, "Last.fm session expired; reconnect", http.StatusConflict)
+				return
+			}
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
 		}

--- a/lastfm.go
+++ b/lastfm.go
@@ -98,7 +98,7 @@ func lastFMStatusHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "User not found", http.StatusNotFound)
 		return
 	}
-	respondJSON(w, map[string]any{"configured": os.Getenv("LASTFM_API_KEY") != "" && os.Getenv("LASTFM_API_SECRET") != "", "connected": user.LastFMSession != "", "username": user.LastFMUsername})
+	respondJSON(w, map[string]any{"configured": os.Getenv("LASTFM_API_KEY") != "" && os.Getenv("LASTFM_API_SECRET") != "", "connected": user.LastFMSession != "", "pending": user.LastFMToken != "", "username": user.LastFMUsername})
 }
 
 func lastFMUpdatedUser(r *http.Request) ([]User, *User) {

--- a/lastfm.go
+++ b/lastfm.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -94,22 +95,34 @@ func lastFMStatusHandler(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, map[string]any{"configured": os.Getenv("LASTFM_API_KEY") != "" && os.Getenv("LASTFM_API_SECRET") != "", "connected": user.LastFMSession != "", "username": user.LastFMUsername})
 }
 
+func lastFMUpdatedUser(r *http.Request) ([]User, *User) {
+	updated := slices.Clone(users)
+	username, _ := r.Context().Value("username").(string)
+	for i := range updated {
+		if updated[i].Username == username {
+			return updated, &updated[i]
+		}
+	}
+	return updated, nil
+}
+
 func lastFMConnectHandler(w http.ResponseWriter, r *http.Request) {
 	result, err := lastFMCall(url.Values{"method": {"auth.getToken"}})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
-	user := currentUser(r)
+	updated, user := lastFMUpdatedUser(r)
 	if user == nil {
 		http.Error(w, "User not found", http.StatusNotFound)
 		return
 	}
 	user.LastFMToken = result.Token
-	if err := saveUsers(users); err != nil {
+	if err := saveUsers(updated); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	users = updated
 	respondJSON(w, map[string]string{"url": "https://www.last.fm/api/auth/?api_key=" + url.QueryEscape(os.Getenv("LASTFM_API_KEY")) + "&token=" + url.QueryEscape(result.Token)})
 }
 
@@ -125,30 +138,32 @@ func lastFMCompleteHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
-	user = currentUser(r)
+	updated, user := lastFMUpdatedUser(r)
 	if user == nil || user.LastFMToken != token {
 		http.Error(w, "Last.fm connection changed", http.StatusConflict)
 		return
 	}
 	user.LastFMUsername, user.LastFMSession, user.LastFMToken = result.Session.Name, result.Session.Key, ""
-	if err := saveUsers(users); err != nil {
+	if err := saveUsers(updated); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	users = updated
 	respondJSON(w, map[string]any{"connected": true, "username": user.LastFMUsername})
 }
 
 func lastFMDisconnectHandler(w http.ResponseWriter, r *http.Request) {
-	user := currentUser(r)
+	updated, user := lastFMUpdatedUser(r)
 	if user == nil {
 		http.Error(w, "User not found", http.StatusNotFound)
 		return
 	}
 	user.LastFMUsername, user.LastFMSession, user.LastFMToken = "", "", ""
-	if err := saveUsers(users); err != nil {
+	if err := saveUsers(updated); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	users = updated
 	respondJSON(w, map[string]any{"connected": false})
 }
 

--- a/lastfm.go
+++ b/lastfm.go
@@ -85,8 +85,6 @@ func lastFMCall(values url.Values) (*lastFMResponse, error) {
 }
 
 func lastFMStatusHandler(w http.ResponseWriter, r *http.Request) {
-	usersMutex.Lock()
-	defer usersMutex.Unlock()
 	user := currentUser(r)
 	if user == nil {
 		http.Error(w, "User not found", http.StatusNotFound)
@@ -101,15 +99,13 @@ func lastFMConnectHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
-	usersMutex.Lock()
-	defer usersMutex.Unlock()
 	user := currentUser(r)
 	if user == nil {
 		http.Error(w, "User not found", http.StatusNotFound)
 		return
 	}
 	user.LastFMToken = result.Token
-	if err := saveUsersUnlocked(); err != nil {
+	if err := saveUsers(users); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -117,29 +113,24 @@ func lastFMConnectHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func lastFMCompleteHandler(w http.ResponseWriter, r *http.Request) {
-	usersMutex.Lock()
 	user := currentUser(r)
 	if user == nil || user.LastFMToken == "" {
-		usersMutex.Unlock()
 		http.Error(w, "No Last.fm connection is pending", http.StatusBadRequest)
 		return
 	}
 	token := user.LastFMToken
-	usersMutex.Unlock()
 	result, err := lastFMCall(url.Values{"method": {"auth.getSession"}, "token": {token}})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
-	usersMutex.Lock()
-	defer usersMutex.Unlock()
 	user = currentUser(r)
 	if user == nil || user.LastFMToken != token {
 		http.Error(w, "Last.fm connection changed", http.StatusConflict)
 		return
 	}
 	user.LastFMUsername, user.LastFMSession, user.LastFMToken = result.Session.Name, result.Session.Key, ""
-	if err := saveUsersUnlocked(); err != nil {
+	if err := saveUsers(users); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -147,15 +138,13 @@ func lastFMCompleteHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func lastFMDisconnectHandler(w http.ResponseWriter, r *http.Request) {
-	usersMutex.Lock()
-	defer usersMutex.Unlock()
 	user := currentUser(r)
 	if user == nil {
 		http.Error(w, "User not found", http.StatusNotFound)
 		return
 	}
 	user.LastFMUsername, user.LastFMSession, user.LastFMToken = "", "", ""
-	if err := saveUsersUnlocked(); err != nil {
+	if err := saveUsers(users); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -169,15 +158,12 @@ func lastFMTrackHandler(method string) http.HandlerFunc {
 			http.Error(w, "Artist and track are required", http.StatusBadRequest)
 			return
 		}
-		usersMutex.Lock()
 		user := currentUser(r)
 		if user == nil || user.LastFMSession == "" {
-			usersMutex.Unlock()
 			http.Error(w, "Last.fm is not connected", http.StatusConflict)
 			return
 		}
 		session := user.LastFMSession
-		usersMutex.Unlock()
 		values := url.Values{"method": {method}, "artist": {track.Artist}, "track": {track.Track}, "sk": {session}}
 		if track.Album != "" {
 			values.Set("album", track.Album)

--- a/lastfm.go
+++ b/lastfm.go
@@ -92,14 +92,17 @@ func lastFMCall(values url.Values) (*lastFMResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	values.Set("api_key", key)
 	values.Set("api_sig", lastFMSign(values, secret))
 	values.Set("format", "json")
+
 	response, err := lastFMHTTPClient.PostForm(lastFMAPIURL, values)
 	if err != nil {
 		return nil, err
 	}
 	defer response.Body.Close()
+
 	var result lastFMResponse
 	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
 		if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
@@ -107,12 +110,15 @@ func lastFMCall(values url.Values) (*lastFMResponse, error) {
 		}
 		return nil, fmt.Errorf("Last.fm: invalid response: %w", err)
 	}
+
 	if result.Error != 0 {
 		return nil, &lastFMError{Code: result.Error, Message: result.Message}
 	}
+
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("Last.fm: HTTP %s", response.Status)
 	}
+
 	return &result, nil
 }
 

--- a/lastfm.go
+++ b/lastfm.go
@@ -27,8 +27,21 @@ type lastFMResponse struct {
 		Name string `json:"name"`
 		Key  string `json:"key"`
 	} `json:"session"`
-	Error   int    `json:"error"`
-	Message string `json:"message"`
+	Error      int    `json:"error"`
+	Message    string `json:"message"`
+	NowPlaying struct {
+		Ignored lastFMIgnoredMessage `json:"ignoredMessage"`
+	} `json:"nowplaying"`
+	Scrobbles struct {
+		Scrobble struct {
+			Ignored lastFMIgnoredMessage `json:"ignoredMessage"`
+		} `json:"scrobble"`
+	} `json:"scrobbles"`
+}
+
+type lastFMIgnoredMessage struct {
+	Code string `json:"code"`
+	Text string `json:"#text"`
 }
 
 type lastFMError struct {
@@ -210,7 +223,8 @@ func lastFMTrackHandler(method string) http.HandlerFunc {
 			}
 			values.Set("timestamp", fmt.Sprint(track.Timestamp))
 		}
-		if _, err := lastFMCall(values); err != nil {
+		result, err := lastFMCall(values)
+		if err != nil {
 			logger.Log.Printf("Last.fm %s failed for %q by %q: %v", method, track.Track, track.Artist, err)
 			var apiErr *lastFMError
 			if errors.As(err, &apiErr) && apiErr.Code == 9 {
@@ -228,6 +242,19 @@ func lastFMTrackHandler(method string) http.HandlerFunc {
 				return
 			}
 			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		ignored := result.NowPlaying.Ignored
+		if method == "track.scrobble" {
+			ignored = result.Scrobbles.Scrobble.Ignored
+		}
+		if ignored.Code != "" && ignored.Code != "0" {
+			message := ignored.Text
+			if message == "" {
+				message = "ignored with code " + ignored.Code
+			}
+			logger.Log.Printf("Last.fm %s ignored %q by %q: %s", method, track.Track, track.Artist, message)
+			http.Error(w, "Last.fm: "+message, http.StatusUnprocessableEntity)
 			return
 		}
 		respondJSON(w, map[string]any{})

--- a/lastfm_test.go
+++ b/lastfm_test.go
@@ -72,6 +72,39 @@ func TestLastFMTrackClearsInvalidSession(t *testing.T) {
 	}
 }
 
+func TestLastFMTrackReportsIgnoredSubmissions(t *testing.T) {
+	oldURL, oldUsers := lastFMAPIURL, users
+	users = []User{{Username: "alice", LastFMSession: "session"}}
+	t.Cleanup(func() { lastFMAPIURL, users = oldURL, oldUsers })
+	t.Setenv("LASTFM_API_KEY", "key")
+	t.Setenv("LASTFM_API_SECRET", "secret")
+
+	for _, test := range []struct {
+		name, path, response string
+		handler              http.HandlerFunc
+	}{
+		{name: "now playing", path: "/api/lastfm/now-playing", handler: lastFMNowPlayingHandler, response: `{"nowplaying":{"ignoredMessage":{"code":"1","#text":"Filtered"}}}`},
+		{name: "scrobble", path: "/api/lastfm/scrobble", handler: lastFMScrobbleHandler, response: `{"scrobbles":{"scrobble":{"ignoredMessage":{"code":"1","#text":"Filtered"}}}}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprint(w, test.response)
+			}))
+			defer server.Close()
+			lastFMAPIURL = server.URL
+
+			req := httptest.NewRequest(http.MethodPost, test.path, bytes.NewBufferString(`{"artist":"Artist","track":"Track"}`))
+			req = req.WithContext(context.WithValue(req.Context(), "username", "alice"))
+			response := httptest.NewRecorder()
+			test.handler(response, req)
+
+			if response.Code != http.StatusUnprocessableEntity || !strings.Contains(response.Body.String(), "Filtered") {
+				t.Fatalf("status = %d, body = %q", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
 func TestLastFMCallExplainsHTTPFailures(t *testing.T) {
 	t.Setenv("LASTFM_API_KEY", "key")
 	t.Setenv("LASTFM_API_SECRET", "secret")

--- a/lastfm_test.go
+++ b/lastfm_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,27 @@ import (
 	"strings"
 	"testing"
 )
+
+func TestLastFMStatusExposesPendingAuthorization(t *testing.T) {
+	oldUsers := users
+	users = []User{{Username: "alice", LastFMToken: "token"}}
+	t.Cleanup(func() { users = oldUsers })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/lastfm", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "username", "alice"))
+	response := httptest.NewRecorder()
+	lastFMStatusHandler(response, req)
+
+	var status struct {
+		Pending bool `json:"pending"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if !status.Pending {
+		t.Fatal("pending authorization was not reported")
+	}
+}
 
 func TestLastFMCallExplainsHTTPFailures(t *testing.T) {
 	t.Setenv("LASTFM_API_KEY", "key")

--- a/lastfm_test.go
+++ b/lastfm_test.go
@@ -34,6 +34,44 @@ func TestLastFMStatusExposesPendingAuthorization(t *testing.T) {
 	}
 }
 
+func TestLastFMTrackClearsInvalidSession(t *testing.T) {
+	useTempDataPath(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"error":9,"message":"Invalid session key"}`)
+	}))
+	defer server.Close()
+
+	oldURL, oldUsers := lastFMAPIURL, users
+	lastFMAPIURL = server.URL
+	users = []User{{Username: "alice", LastFMUsername: "lastfm-alice", LastFMSession: "invalid"}}
+	t.Cleanup(func() { lastFMAPIURL, users = oldURL, oldUsers })
+	t.Setenv("LASTFM_API_KEY", "key")
+	t.Setenv("LASTFM_API_SECRET", "secret")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/lastfm/now-playing", bytes.NewBufferString(`{"artist":"Artist","track":"Track"}`))
+	req = req.WithContext(context.WithValue(req.Context(), "username", "alice"))
+	response := httptest.NewRecorder()
+	lastFMNowPlayingHandler(response, req)
+
+	if response.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusConflict, response.Body.String())
+	}
+	if users[0].LastFMSession != "" || users[0].LastFMUsername != "" {
+		t.Fatalf("invalid connection was not cleared: %#v", users[0])
+	}
+	data, err := os.ReadFile(usersFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted []User
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if persisted[0].LastFMSession != "" {
+		t.Fatalf("invalid session was still persisted: %#v", persisted[0])
+	}
+}
+
 func TestLastFMCallExplainsHTTPFailures(t *testing.T) {
 	t.Setenv("LASTFM_API_KEY", "key")
 	t.Setenv("LASTFM_API_SECRET", "secret")

--- a/lastfm_test.go
+++ b/lastfm_test.go
@@ -38,6 +38,26 @@ func TestLastFMTrackRoundsFractionalDuration(t *testing.T) {
 	}
 }
 
+func TestLastFMDisconnectKeepsMemoryWhenPersistenceFails(t *testing.T) {
+	oldDataPath, oldUsersFilePath, oldUsers := dataPath, usersFilePath, users
+	dataPath = t.TempDir() + "/missing"
+	usersFilePath = dataPath + "/users.json"
+	users = []User{{Username: "alice", LastFMUsername: "lastfm-alice", LastFMSession: "session", LastFMToken: "token"}}
+	t.Cleanup(func() { dataPath, usersFilePath, users = oldDataPath, oldUsersFilePath, oldUsers })
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/lastfm", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "username", "alice"))
+	response := httptest.NewRecorder()
+	lastFMDisconnectHandler(response, req)
+
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+	}
+	if users[0].LastFMSession != "session" || users[0].LastFMToken != "token" {
+		t.Fatalf("user changed after failed persistence: %#v", users[0])
+	}
+}
+
 func TestLastFMConnectionsBelongToEachUser(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := r.FormValue("token")

--- a/lastfm_test.go
+++ b/lastfm_test.go
@@ -6,9 +6,40 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"strings"
 	"testing"
 )
+
+func TestLastFMCallExplainsHTTPFailures(t *testing.T) {
+	t.Setenv("LASTFM_API_KEY", "key")
+	t.Setenv("LASTFM_API_SECRET", "secret")
+	oldURL := lastFMAPIURL
+	t.Cleanup(func() { lastFMAPIURL = oldURL })
+
+	for _, test := range []struct {
+		name, body, want string
+		status           int
+	}{
+		{name: "non-JSON", status: http.StatusServiceUnavailable, body: "try later", want: "HTTP 503 Service Unavailable"},
+		{name: "Last.fm JSON", status: http.StatusBadRequest, body: `{"error":6,"message":"Invalid parameters"}`, want: "Last.fm: Invalid parameters"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.status)
+				fmt.Fprint(w, test.body)
+			}))
+			defer server.Close()
+			lastFMAPIURL = server.URL
+
+			_, err := lastFMCall(url.Values{"method": {"test"}})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
 
 func TestLastFMTrackRoundsFractionalDuration(t *testing.T) {
 	var duration string

--- a/lastfm_test.go
+++ b/lastfm_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -8,6 +9,34 @@ import (
 	"os"
 	"testing"
 )
+
+func TestLastFMTrackRoundsFractionalDuration(t *testing.T) {
+	var duration string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duration = r.FormValue("duration")
+		fmt.Fprint(w, `{}`)
+	}))
+	defer server.Close()
+
+	oldURL, oldUsers := lastFMAPIURL, users
+	lastFMAPIURL = server.URL
+	users = []User{{Username: "alice", LastFMSession: "session"}}
+	t.Cleanup(func() { lastFMAPIURL, users = oldURL, oldUsers })
+	t.Setenv("LASTFM_API_KEY", "key")
+	t.Setenv("LASTFM_API_SECRET", "secret")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/lastfm/now-playing", bytes.NewBufferString(`{"artist":"Artist","track":"Track","duration":123.5}`))
+	req = req.WithContext(context.WithValue(req.Context(), "username", "alice"))
+	response := httptest.NewRecorder()
+	lastFMNowPlayingHandler(response, req)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("%d %s", response.Code, response.Body.String())
+	}
+	if duration != "124" {
+		t.Fatalf("duration = %q, want 124", duration)
+	}
+}
 
 func TestLastFMConnectionsBelongToEachUser(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/lastfm_test.go
+++ b/lastfm_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestLastFMConnectionsBelongToEachUser(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.FormValue("token")
+		fmt.Fprintf(w, `{"session":{"name":"lastfm-%s","key":"session-%s"}}`, token, token)
+	}))
+	defer server.Close()
+
+	oldURL, oldUsers := lastFMAPIURL, users
+	lastFMAPIURL = server.URL
+	users = []User{{Username: "alice", LastFMToken: "alice-token"}, {Username: "bob", LastFMToken: "bob-token"}}
+	t.Cleanup(func() { lastFMAPIURL, users = oldURL, oldUsers })
+	t.Setenv("LASTFM_API_KEY", "key")
+	t.Setenv("LASTFM_API_SECRET", "secret")
+
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+
+	for _, username := range []string{"alice", "bob"} {
+		req := httptest.NewRequest(http.MethodPost, "/api/lastfm/complete", nil)
+		req = req.WithContext(context.WithValue(req.Context(), "username", username))
+		response := httptest.NewRecorder()
+		lastFMCompleteHandler(response, req)
+		if response.Code != http.StatusOK {
+			t.Fatalf("%s: %d %s", username, response.Code, response.Body.String())
+		}
+	}
+
+	if users[0].LastFMSession != "session-alice-token" || users[1].LastFMSession != "session-bob-token" {
+		t.Fatalf("connections crossed users: %#v", users)
+	}
+}


### PR DESCRIPTION
## Summary
- persist Last.fm tokens and sessions on each Beatstream user
- add connect, complete, disconnect, now-playing, and scrobble API endpoints
- wire Settings and playback scrobbling into the React frontend
- document the required Last.fm API credentials

## Verification
- `npm run typecheck`
- `npm run build`
- `docker build -f Dockerfile.hub -t beatstream-lastfm-check .`
- `docker run --rm beatstream-lastfm-test go test ./...`

Repository-wide frontend lint still reports pre-existing violations outside this change.