### PR TITLE
feat: expose song file extension

### DIFF
--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -7,4 +7,5 @@ interface Song {
   path: string;
   title: string;
   track_num: number;
+  extension: string;
 }

--- a/helpers.go
+++ b/helpers.go
@@ -44,13 +44,14 @@ func newSongFromFile(absolutePath string) (*Song, error) {
 
 	// Create new song
 	song := &Song{
-		Filename: filepath.Base(absolutePath),
-		Path:     strings.TrimPrefix(absolutePath, MusicPath),
-		Title:    file.Title(),
-		Artist:   file.Artist(),
-		Album:    file.Album(),
-		TrackNum: trackNumPtr,
-		Length:   int(file.Length().Seconds()),
+		Filename:  filepath.Base(absolutePath),
+		Path:      strings.TrimPrefix(absolutePath, MusicPath),
+		Extension: strings.TrimPrefix(strings.ToLower(filepath.Ext(absolutePath)), "."),
+		Title:     file.Title(),
+		Artist:    file.Artist(),
+		Album:     file.Album(),
+		TrackNum:  trackNumPtr,
+		Length:    int(file.Length().Seconds()),
 	}
 
 	return song, nil

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -7,17 +7,18 @@ import (
 
 func TestNewSongFromFileMetadata(t *testing.T) {
 	tests := []struct {
-		name     string
-		file     string
-		duration int
+		name      string
+		file      string
+		extension string
+		duration  int
 	}{
-		{"MP3", "tagged.mp3", 3},
-		{"VBR MP3 without Xing", "tagged-vbr-no-xing.mp3", 10},
-		{"Ogg", "tagged.ogg", 3},
-		{"FLAC", "tagged.flac", 3},
-		{"M4A", "tagged.m4a", 3},
-		{"raw AAC", "tagged.aac", 3},
-		{"WAV with RIFF metadata", "tagged.wav", 3},
+		{"MP3", "tagged.mp3", "mp3", 3},
+		{"VBR MP3 without Xing", "tagged-vbr-no-xing.mp3", "mp3", 10},
+		{"Ogg", "tagged.ogg", "ogg", 3},
+		{"FLAC", "tagged.flac", "flac", 3},
+		{"M4A", "tagged.m4a", "m4a", 3},
+		{"raw AAC", "tagged.aac", "aac", 3},
+		{"WAV with RIFF metadata", "tagged.wav", "wav", 3},
 	}
 
 	for _, tt := range tests {
@@ -30,6 +31,9 @@ func TestNewSongFromFileMetadata(t *testing.T) {
 				t.Fatal("newSongFromFile returned no song")
 			}
 
+			if song.Extension != tt.extension {
+				t.Errorf("extension = %q, want %q", song.Extension, tt.extension)
+			}
 			if song.Title != "Fixture Title" {
 				t.Errorf("title = %q, want %q", song.Title, "Fixture Title")
 			}

--- a/song.go
+++ b/song.go
@@ -7,13 +7,14 @@ import (
 )
 
 type Song struct {
-	Filename string `json:"filename"`
-	Path     string `json:"path"`
-	Title    string `json:"title"`
-	Artist   string `json:"artist"`
-	Album    string `json:"album"`
-	TrackNum *int   `json:"track_num"` // we use pointer for string, so we can set it to "nil" if there is no track number
-	Length   int    `json:"length"`
+	Filename  string `json:"filename"`
+	Path      string `json:"path"`
+	Extension string `json:"extension"`
+	Title     string `json:"title"`
+	Artist    string `json:"artist"`
+	Album     string `json:"album"`
+	TrackNum  *int   `json:"track_num"` // we use pointer for string, so we can set it to "nil" if there is no track number
+	Length    int    `json:"length"`
 }
 
 // For sorting songs in a natural way (artist, album, track number)


### PR DESCRIPTION
## Summary

- add an `extension` field to songs and their JSON representation
- derive the normalized lowercase extension in `newSongFromFile`
- cover MP3, Ogg, FLAC, M4A, AAC, and WAV extensions in the metadata contract
- keep the frontend `Song` declaration aligned with the API

## Verification

- production Docker build passes, including the frontend TypeScript build
- MP3, Ogg, FLAC, M4A, and WAV contract cases pass on TagLib 2.0.2
- expected red baseline remains for raw AAC metadata and the no-Xing VBR MP3 duration
- all returned songs pass the new extension assertions