### PR TITLE
Expose media library refresh status

### DIFF
--- a/api.go
+++ b/api.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/Darep/Beatstream/logger"
 	"github.com/go-chi/chi/v5"
@@ -19,7 +20,7 @@ import (
 
 const SongsFilePath = "songs.json"
 
-var refreshMutex = &sync.Mutex{}
+var songsRefreshing atomic.Bool
 var songsMutex = &sync.RWMutex{}
 
 // Define valid audio file extensions
@@ -67,6 +68,7 @@ func registerRoutes() *chi.Mux {
 
 		r.Get("/songs", songsHandler)
 		r.Get("/songs/play", playHandler)
+		r.Get("/songs/refresh", refreshStatusHandler)
 		r.Post("/songs/refresh", refreshHandler)
 
 		// r.Put("/lastfm", lastfmHandler)
@@ -223,11 +225,11 @@ func playHandler(w http.ResponseWriter, r *http.Request) {
 
 // POST /api/songs/refresh
 func refreshHandler(w http.ResponseWriter, r *http.Request) {
-	if !refreshMutex.TryLock() {
+	if !songsRefreshing.CompareAndSwap(false, true) {
 		http.Error(w, "Another refresh operation is already in progress", http.StatusConflict)
 		return
 	}
-	defer refreshMutex.Unlock()
+	defer songsRefreshing.Store(false)
 
 	err := refreshSongs()
 	if err != nil {
@@ -237,6 +239,11 @@ func refreshHandler(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		http.ServeFile(w, r, SongsFilePath)
 	}
+}
+
+// GET /api/songs/refresh
+func refreshStatusHandler(w http.ResponseWriter, _ *http.Request) {
+	respondJSON(w, map[string]bool{"refreshing": songsRefreshing.Load()})
 }
 
 func refreshSongs() error {

--- a/api_test.go
+++ b/api_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestDeleteOtherSessions(t *testing.T) {
 	sessions = []Session{
@@ -13,5 +18,21 @@ func TestDeleteOtherSessions(t *testing.T) {
 
 	if len(sessions) != 2 || sessions[0].Token != "current" || sessions[1].Token != "someone-else" {
 		t.Fatalf("unexpected remaining sessions: %#v", sessions)
+	}
+}
+
+func TestRefreshStatusHandler(t *testing.T) {
+	songsRefreshing.Store(true)
+	t.Cleanup(func() { songsRefreshing.Store(false) })
+
+	response := httptest.NewRecorder()
+	refreshStatusHandler(response, httptest.NewRequest(http.MethodGet, "/api/songs/refresh", nil))
+
+	var status map[string]bool
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if response.Code != http.StatusOK || !status["refreshing"] {
+		t.Fatalf("unexpected response: status=%d body=%v", response.Code, status)
 	}
 }

--- a/frontend/src/components/AppTop.tsx
+++ b/frontend/src/components/AppTop.tsx
@@ -17,7 +17,6 @@ export const AppTop = ({ className }: { className?: string }) => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [openModalName, setOpenModalName] = useState<'settings'>();
   const [isRefreshDone, setIsRefreshDone] = useState(false);
-  const [isRefreshing, setIsRefreshing] = useState(false);
   const [refreshError, setRefreshError] = useState<string | undefined>();
   const refreshDoneTimer = useRef<number | undefined>(undefined);
   const wasRefreshing = useRef(false);
@@ -37,7 +36,6 @@ export const AppTop = ({ className }: { className?: string }) => {
   };
 
   const handleRefresh = async () => {
-    setIsRefreshing(true);
     mutate('/api/songs/refresh', { refreshing: true }, false);
 
     if (refreshDoneTimer.current) {
@@ -56,7 +54,6 @@ export const AppTop = ({ className }: { className?: string }) => {
     } catch (error) {
       setRefreshError(error!.toString());
     } finally {
-      setIsRefreshing(false);
       mutate('/api/songs/refresh');
     }
   };
@@ -72,7 +69,7 @@ export const AppTop = ({ className }: { className?: string }) => {
 
       <div className="right">
         <div className="status-bar">
-          {isRefreshing || refreshStatus?.refreshing ? (
+          {refreshStatus?.refreshing ? (
             <div className="media-library-refresh">
               <img src={preloader} alt="" />
               <span>Refreshing media library&hellip;</span>

--- a/frontend/src/components/AppTop.tsx
+++ b/frontend/src/components/AppTop.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { mutate } from 'swr';
 
-import { useSession } from 'hooks/swr';
+import { useRefreshStatus, useSession } from 'hooks/swr';
 import { request } from 'utils/api';
 
 import preloader from 'assets/preloader.gif';
@@ -13,12 +13,21 @@ import { Button } from './common/Button';
 
 export const AppTop = ({ className }: { className?: string }) => {
   const { user } = useSession();
+  const { data: refreshStatus } = useRefreshStatus();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [openModalName, setOpenModalName] = useState<'settings'>();
   const [isRefreshDone, setIsRefreshDone] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [refreshError, setRefreshError] = useState<string | undefined>();
   const refreshDoneTimer = useRef<number | undefined>(undefined);
+  const wasRefreshing = useRef(false);
+
+  useEffect(() => {
+    if (wasRefreshing.current && !refreshStatus?.refreshing) {
+      mutate('/api/songs');
+    }
+    wasRefreshing.current = refreshStatus?.refreshing ?? false;
+  }, [refreshStatus?.refreshing]);
 
   const toggleDropdown = () => {
     setDropdownOpen(!dropdownOpen);
@@ -26,6 +35,7 @@ export const AppTop = ({ className }: { className?: string }) => {
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
+    mutate('/api/songs/refresh', { refreshing: true }, false);
 
     if (refreshDoneTimer.current) {
       clearTimeout(refreshDoneTimer.current);
@@ -44,6 +54,7 @@ export const AppTop = ({ className }: { className?: string }) => {
       setRefreshError(error!.toString());
     } finally {
       setIsRefreshing(false);
+      mutate('/api/songs/refresh');
     }
   };
 
@@ -58,7 +69,7 @@ export const AppTop = ({ className }: { className?: string }) => {
 
       <div className="right">
         <div className="status-bar">
-          {isRefreshing ? (
+          {isRefreshing || refreshStatus?.refreshing ? (
             <div className="media-library-refresh">
               <img src={preloader} alt="" />
               <span>Refreshing media library&hellip;</span>

--- a/frontend/src/components/AppTop.tsx
+++ b/frontend/src/components/AppTop.tsx
@@ -22,10 +22,13 @@ export const AppTop = ({ className }: { className?: string }) => {
   const refreshDoneTimer = useRef<number | undefined>(undefined);
   const wasRefreshing = useRef(false);
 
+  // Keep track of refresh status in case we should reload songs
   useEffect(() => {
     if (wasRefreshing.current && !refreshStatus?.refreshing) {
+      // Refresh the song list since we were just refreshing
       mutate('/api/songs');
     }
+
     wasRefreshing.current = refreshStatus?.refreshing ?? false;
   }, [refreshStatus?.refreshing]);
 

--- a/frontend/src/hooks/swr.ts
+++ b/frontend/src/hooks/swr.ts
@@ -26,3 +26,8 @@ export const useSession = (opts?: RequestInit, swrOpts?: SWRConfiguration) => {
 };
 
 export const useSongs = ({ skip }: { skip?: boolean } = {}) => useSWRImmutable(skip ? null : '/api/songs', fetcher);
+
+export const useRefreshStatus = () =>
+  useApi<{ refreshing: boolean }>('/api/songs/refresh', undefined, {
+    refreshInterval: (status) => (status?.refreshing ? 1000 : 0),
+  });


### PR DESCRIPTION
## Summary
- expose refresh state from GET /api/songs/refresh
- use the atomic refresh state for both status and concurrency control
- show refresh status on app open and poll only until refresh completes
- revalidate the song library after an externally started refresh finishes

## Verification
- make format
- targeted Go tests pass
- Go vet and development/production builds pass
- frontend formatting and production build pass
- Docker Compose build passes
- make check reaches pre-existing failures in TestNewSongFromFileMetadata for the VBR MP3 and raw AAC fixtures; the same failures reproduce on master