### PR TITLE
chore: upgrade to Go 1.26

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.25.0
+          go-version: 1.26.0
           cache: true
       - uses: actions/setup-node@v6
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for local dev
-FROM golang:1.25.0
+FROM golang:1.26.0
 
 WORKDIR /app
 

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -8,7 +8,7 @@ COPY frontend/ .
 RUN npm install && npm run build
 
 # ---- Backend build ----
-FROM golang:1.25.0 AS build
+FROM golang:1.26.0 AS build
 
 WORKDIR /app
 
@@ -30,7 +30,7 @@ COPY --from=frontend /app/dist /app/frontend/dist
 RUN CGO_ENABLED=1 go build -tags production -o /beatstream
 
 # ---- Runtime ----
-FROM golang:1.25.0 AS runtime
+FROM golang:1.26.0 AS runtime
 
 ENV MUSIC_PATH=/music
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open http://0.0.0.0:8080 on your browser. Log in and wait when indexing ends, re
 
 ### Manual Install
 
-Requirements: Go 1.22 or newer. Node.js 20 or newer. TagLib (C bindings) e.g. libtagc
+Requirements: Go 1.26 or newer. Node.js 20 or newer. TagLib (C bindings) e.g. libtagc
 
 ```bash
 git clone https://github.com/Darep/Beatstream

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Darep/Beatstream
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-chi/chi/v5 v5.3.1


### PR DESCRIPTION
## Summary
- require Go 1.26.0 in the module and CI
- use Go 1.26.0 in development and production Docker images
- update the documented Go requirement

## Verification
- `make format`
- `go vet ./...`
- `go test -skip ^TestNewSongFromFileMetadata$ ./...`
- frontend format and production build
- development Docker Compose build
- production `Dockerfile.hub` build and HTTP 200 smoke test

## Known baseline failure
`make check` reaches `go test ./...` and fails in `TestNewSongFromFileMetadata` for the VBR MP3 and raw AAC fixtures. The same failures reproduce on unchanged `master` with Go 1.25.0, and the current `master` Integration run already fails in this metadata test, so this is not introduced by the Go 1.26 upgrade.